### PR TITLE
PR-02.5: Lighthouse CI完全対応（NO_FCP解決）

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -5,14 +5,14 @@
       "staticDistDir": "build",
       "url": ["/index.html"],
       "settings": {
-        "chromeFlags": "--no-sandbox --disable-gpu",
+        "chromeFlags": "--no-sandbox --disable-gpu --disable-dev-shm-usage",
         "maxWaitForLoad": 60000,
         "skipAudits": ["uses-http2"]
       }
     },
     "assert": {
       "assertions": {
-        "categories:accessibility": ["warn", { "minScore": 0.95 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
         "categories:performance": ["warn", { "minScore": 0.85 }],
         "categories:best-practices": "off",
         "categories:seo": "off",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "baseball-score",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",


### PR DESCRIPTION
## 目的
CI環境でのLighthouse CI正常実行とスコア監視の自動化

## 変更内容

### 1. homepage設定の調整（根本原因の解決）
- `package.json`の`homepage`を`"."`から`"/"`に変更
- これにより、ビルドされたアセットが絶対パスになり、Lighthouse CIの静的サーバーで正しく読み込める

### 2. Lighthouse CI設定の最適化
- `.lighthouserc.json`の`chromeFlags`に`--disable-dev-shm-usage`を追加（CI環境の安定性向上）
- `categories:accessibility`を`warn`から`error`に変更（スコア95%未満でCI失敗）

### 3. CI/CDワークフローの調整
- `.github/workflows/ci.yml`から`continue-on-error: true`を削除
- Lighthouse CIの失敗でCIが正しく失敗するように戻す

## 問題の詳細

PR-02で導入したLighthouse CIが、CI環境で以下のエラーを発生：
```
Runtime error: The page did not paint any content (NO_FCP)
```

**根本原因**:
- `package.json`の`homepage: "."`により、ビルドされたアセットが相対パス（`./static/js/...`）で出力
- Lighthouse CIの内部静的サーバーでは、相対パスのJSファイルが正しく読み込めない
- Reactアプリが初期化されず、First Contentful Paintが発生しない

## 検証結果

✅ **ローカル検証**:
- `npm run build` → 成功（アセットが`/static/js/...`で出力）
- `npx lhci autorun` → 成功（NO_FCPエラー無し）
- 全テスト通過（Jest, ESLint, TypeScript）

✅ **期待される動作**:
- CI環境でLighthouse CIが正常に完了
- Accessibilityスコア < 95%の場合はCI失敗
- 本来の品質ゲートが正しく機能

## 関連

- 親タスク: PR-02（a11yテスト基盤）
- 計画書: `@ui_improve_plan_v2.md` PR-02.5セクション
- 依存: PR-02がマージ済み

## チェックリスト

- [x] homepage設定を`"/"`に変更
- [x] Lighthouse CI設定の最適化
- [x] continue-on-errorの削除
- [x] ローカルビルド確認
- [x] ローカルLHCI実行確認
- [x] 全テスト通過確認