### PR TITLE
fix: 試合一覧から新しい試合を作成時に画面が遷移しない問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -478,6 +478,10 @@ const MainApp: React.FC<{
   const handleNewGame = () => {
     setGame(initialGame);
     handleMenuClose();
+    // 試合一覧画面が表示されている場合は閉じる
+    if (showGameList) {
+      setShowGameList(false);
+    }
     // チーム管理画面が表示されている場合は閉じる
     if (showTeamManagement) {
       setShowTeamManagement(false);


### PR DESCRIPTION
## 問題

試合一覧を表示してから「新しい試合」ボタンを押しても画面が変わらず、もう一度「試合一覧を表示」を押すと新しい試合が始まるという問題が発生していました。

## 原因

`handleNewGame`関数で、`showGameList`をfalseにする処理が抜けていたため、試合一覧画面が表示されたままになっていました。

## 修正内容

`handleNewGame`関数に`showGameList`を閉じる処理を追加：

```tsx
const handleNewGame = () => {
  setGame(initialGame);
  handleMenuClose();
  // 試合一覧画面が表示されている場合は閉じる
  if (showGameList) {
    setShowGameList(false);  // ← 追加
  }
  // チーム管理画面が表示されている場合は閉じる
  if (showTeamManagement) {
    setShowTeamManagement(false);
  }
  // 通算成績画面が表示されている場合は閉じる
  if (showTeamStats) {
    setShowTeamStats(false);
  }
  // チーム選択ダイアログを表示せず、直接新しい試合画面に遷移
  // showTeamSelectionDialog();
};
```

## 修正後の動作

- 試合一覧から「新しい試合」を押すと、即座に新しい試合画面に遷移します
- チーム管理、通算成績からも同様に正しく動作します
- メニューを開く → 試合一覧を表示 → 新しい試合 の流れがスムーズになります

## テスト結果

```
✅ ESLint: パス
✅ TypeScript: パス
✅ Jest: 全テストパス (4 passed, 8 tests)
```

## 影響範囲

- `src/App.tsx`の`handleNewGame`関数のみ
- 既存の機能に影響なし
- 他の画面遷移（チーム管理、通算成績）は既に正しく実装されていた

## 関連

- PR-08で遅延ロードを導入した際に、この動作確認が漏れていました
- 小さなバグ修正なので、すぐにマージ可能です

## レビュー観点

1. 試合一覧から「新しい試合」ボタンを押した際の動作確認
2. 他の画面（チーム管理、通算成績）からの「新しい試合」動作も正常か
3. コードの一貫性（他の画面を閉じる処理と同じパターン）