### PR TITLE
fix: Deployment Readinessジョブのカバレッジエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,8 @@ jobs:
           name: build-files
           path: build/
 
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
+      - name: Run tests with coverage
+        run: npm test -- --coverage --watchAll=false
 
       - name: Check test coverage threshold
         run: node scripts/check-coverage.js


### PR DESCRIPTION
## 問題
Deployment Readinessジョブで以下のエラーが発生していました：

```
❌ Coverage summary not found: /home/runner/work/baseball-score/baseball-score/coverage/coverage-summary.json
```

## 原因
- `test`ジョブはNode.js 16, 18, 20で並行実行され、カバレッジのアップロードはNode.js 18でのみ実行されます
- `deployment-check`ジョブがアーティファクトをダウンロードしようとしても、タイミングによってはカバレッジファイルが利用可能になっていない可能性がありました

## 修正内容
- `deployment-check`ジョブで、アーティファクトのダウンロードではなく、テストを再実行してカバレッジを生成するように変更
- これにより、カバレッジファイルが確実に存在し、`check-coverage.js`スクリプトが正常に動作します

## 変更ファイル
- `.github/workflows/ci.yml`

## テスト方法
このPRをマージした後、mainブランチへのプッシュ時に`Deployment Readiness`ジョブが成功することを確認してください。

関連: https://github.com/takurot/baseball-score/actions/runs/18312028766/job/52142942086