### PR TITLE
test(deps): enforce safe transitive dependency floors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4755,13 +4755,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "license": "MIT"
@@ -9113,7 +9106,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -12630,9 +12625,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -12978,9 +12973,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -13425,7 +13420,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -14004,13 +14001,18 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.7.0",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/postcss-loader": {
@@ -14640,6 +14642,15 @@
       "version": "2.0.14",
       "license": "CC0-1.0"
     },
+    "node_modules/postcss-svgo/node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/postcss-svgo/node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
@@ -14648,15 +14659,17 @@
       }
     },
     "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "2.8.0",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -18257,7 +18270,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,22 @@
     "postcss": "^8.4.31",
     "webpack-dev-server": "^5.2.2",
     "qs": "^6.14.1",
-    "bfj": "^9.0.0"
+    "bfj": "^9.0.0",
+    "lodash": "^4.18.1",
+    "node-forge": "^1.4.0",
+    "flatted": "^3.4.2",
+    "path-to-regexp": "0.1.13",
+    "postcss-svgo": {
+      "svgo": "^2.8.1"
+    },
+    "cssnano": {
+      "yaml": "^1.10.3"
+    },
+    "cosmiconfig": {
+      "yaml": "^1.10.3"
+    },
+    "postcss-load-config": {
+      "yaml": "^2.8.3"
+    }
   }
 }

--- a/src/utils/__tests__/dependencyOverrides.test.ts
+++ b/src/utils/__tests__/dependencyOverrides.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path from 'path';
+
+type PackageLock = {
+  packages?: Record<string, { version?: string }>;
+};
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const packageLockPath = path.join(repoRoot, 'package-lock.json');
+
+const readPackageLock = (): PackageLock =>
+  JSON.parse(fs.readFileSync(packageLockPath, 'utf8')) as PackageLock;
+
+const getInstalledVersion = (
+  packageLock: PackageLock,
+  packagePath: string
+): string => {
+  const version = packageLock.packages?.[packagePath]?.version;
+  if (!version) {
+    throw new Error(`Package not found in lockfile: ${packagePath}`);
+  }
+
+  return version;
+};
+
+const parseVersion = (version: string): [number, number, number] => {
+  const normalized = version.replace(/^[^\d]*/, '').split('.');
+  return [
+    Number.parseInt(normalized[0] ?? '0', 10),
+    Number.parseInt(normalized[1] ?? '0', 10),
+    Number.parseInt(normalized[2] ?? '0', 10),
+  ];
+};
+
+const isGte = (actual: string, minimum: string): boolean => {
+  const actualParts = parseVersion(actual);
+  const minimumParts = parseVersion(minimum);
+
+  for (let index = 0; index < 3; index += 1) {
+    if (actualParts[index] > minimumParts[index]) {
+      return true;
+    }
+
+    if (actualParts[index] < minimumParts[index]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+describe('dependency overrides policy', () => {
+  it.each([
+    ['node_modules/lodash', '4.18.1'],
+    ['node_modules/node-forge', '1.4.0'],
+    ['node_modules/flatted', '3.4.2'],
+    ['node_modules/path-to-regexp', '0.1.13'],
+    ['node_modules/postcss-svgo/node_modules/svgo', '2.8.1'],
+    ['node_modules/postcss-load-config/node_modules/yaml', '2.8.3'],
+    ['node_modules/yaml', '1.10.3'],
+  ])('keeps %s at or above %s', (packagePath, minimumVersion) => {
+    const packageLock = readPackageLock();
+    const installedVersion = getInstalledVersion(packageLock, packagePath);
+
+    expect(isGte(installedVersion, minimumVersion)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a lockfile regression test for selected safe transitive dependency floors
- apply low-risk npm overrides for lodash, node-forge, flatted, path-to-regexp, svgo, and yaml paths
- reduce `npm audit` findings from 26 to 20 locally

## Testing
- npm run ci:local
- npm audit --audit-level=high
