### PR TITLE
fix(deps): remove blanket minimatch override keeping nested pins only

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     },
     "picomatch": "^4.0.4",
     "serialize-javascript": "^7.0.3",
-    "minimatch": "^3.1.4",
     "sucrase": {
       "glob": {
         "minimatch": "^9.0.7"


### PR DESCRIPTION
## 概要

Issue #191 の受け入れ基準のうち、未達だった「root レベルの blanket な minimatch override の削除（nested override のみ残す）」を実施しました。

## Issue 前提の検証結果（再現不可の記録）

Issue は「overrides が npm 上に存在しないバージョンを pin し `npm install` が ETARGET で失敗する」とされていますが、**現時点の npm registry では指摘された全バージョンが実在し、`npm install` / `npm ci` とも ETARGET なしで成功します**:

| パッケージ | Issue の指摘 | 現 registry での解決 |
|---|---|---|
| lodash | `^4.18.1` 不存在 | 4.18.1 が実在 |
| node-forge | `^1.4.0` 不存在 | 1.4.0 が実在 |
| flatted | `^3.4.2` 不存在 | 3.4.4 に解決 |
| path-to-regexp | `0.1.13` 不存在 | 0.1.13 が実在 |
| bfj | `^9.0.0` 不存在 | 9.1.3 に解決 |
| picomatch | `^4.0.4` 不存在 | 4.0.5 に解決 |
| serialize-javascript | `^7.0.3` 不存在 | 7.1.0 に解決 |
| yaml (cssnano/cosmiconfig) | `^1.10.3` 不存在 | 1.10.3 が実在 |
| minimatch (root/filelist) | 不存在 | 3.1.5 / 5.1.9 に解決 |

Issue 記載の「実際の最新」（lodash 4.17.21 等）は古い registry データです。これらの pin は #142 で「安全な transitive dependency の下限」として意図的に導入され、`src/utils/__tests__/dependencyOverrides.test.ts` が lockfile のバージョンを検証しているため、Issue 記載バージョンへの変更は行いません（下げると #142 の意図とテストに反する）。

## 変更内容

- `package.json`: overrides から root レベルの `"minimatch": "^3.1.4"` を削除
  - nested override（`sucrase.glob.minimatch ^9.0.7`、`filelist.minimatch ^5.1.8`）は維持
  - blanket pin は glob ≥8 等 minimatch 5–10 を要求する consumer を壊す潜在リスクがあった
  - 現在の依存グラフでは blanket pin 有無に関わらず全 minimatch 3.x consumer が自然に 3.1.5 に解決するため、`package-lock.json` の差分はなし

## 受け入れ基準への対応

- [x] `npm install` が ETARGET なしで成功する → 元から成功（上記の通り再現不可。本 PR でも `npm install` / `npm ci` を確認）
- [x] 各 override が実在バージョンを指している → 全 spec を `npm view` で検証済み（実在）
- [x] blanket minimatch pin を削除し nested override のみ残す → 本 PR で対応

## 実行したテスト

- `npm install` / `npm ci`（ETARGET なし）
- `npm run ci:local`（prettier / lint / tsc / test:ci / build 全通過）
- `src/utils/__tests__/dependencyOverrides.test.ts`（7/7 合格）

## 影響範囲

- UI 変更: なし
- Firestore スキーマ・セキュリティルール: 影響なし
- `package-lock.json`: 差分なし（blanket pin は実グラフに無影響）

Closes #191