### PR TITLE
fix(firebase): enforce ownership on game update and strip PII from shared games

### DIFF
--- a/src/firebase/__tests__/gameService.test.ts
+++ b/src/firebase/__tests__/gameService.test.ts
@@ -1,0 +1,143 @@
+import { getDoc, updateDoc, addDoc } from 'firebase/firestore';
+import { Game } from '../../types';
+import { getCurrentUser } from '../authService';
+import { saveGame, getSharedGameById } from '../gameService';
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  getDocs: jest.fn(),
+  doc: jest.fn(() => ({})),
+  getDoc: jest.fn(),
+  query: jest.fn(),
+  orderBy: jest.fn(),
+  serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+  deleteDoc: jest.fn(),
+  where: jest.fn(),
+  updateDoc: jest.fn(),
+}));
+
+jest.mock('../config', () => ({ db: {} }));
+
+jest.mock('../authService', () => ({ getCurrentUser: jest.fn() }));
+
+const mockedGetDoc = getDoc as jest.Mock;
+const mockedUpdateDoc = updateDoc as jest.Mock;
+const mockedAddDoc = addDoc as jest.Mock;
+const mockedGetCurrentUser = getCurrentUser as jest.Mock;
+
+const makeGame = (overrides: Partial<Game> = {}): Game =>
+  ({
+    id: 'game-1',
+    date: '2026-08-17',
+    currentInning: 1,
+    homeTeam: { id: 'h', name: 'ホーム', players: [], atBats: [] },
+    awayTeam: { id: 'a', name: 'アウェイ', players: [], atBats: [] },
+    ...overrides,
+  }) as Game;
+
+describe('saveGame (update path)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetCurrentUser.mockReturnValue({
+      uid: 'user-1',
+      email: 'me@example.com',
+    });
+  });
+
+  it('rejects when the existing game belongs to another user', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({ userId: 'someone-else' }),
+    });
+
+    await expect(saveGame(makeGame())).rejects.toThrow(
+      'このデータにアクセスする権限がありません'
+    );
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the existing game does not exist', async () => {
+    mockedGetDoc.mockResolvedValue({ exists: () => false });
+
+    await expect(saveGame(makeGame())).rejects.toThrow(
+      'データが見つかりません'
+    );
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('updates own game without id and createdAt fields', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({ userId: 'user-1' }),
+    });
+
+    await saveGame(makeGame());
+
+    expect(mockedUpdateDoc).toHaveBeenCalledTimes(1);
+    const payload = mockedUpdateDoc.mock.calls[0][1];
+    expect(payload).not.toHaveProperty('id');
+    expect(payload).not.toHaveProperty('createdAt');
+    expect(payload.userId).toBe('user-1');
+  });
+});
+
+describe('saveGame (create path)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetCurrentUser.mockReturnValue({
+      uid: 'user-1',
+      email: 'me@example.com',
+    });
+    mockedAddDoc.mockResolvedValue({ id: 'new-game' });
+  });
+
+  it('creates a new document without ownership lookup', async () => {
+    await saveGame(makeGame({ id: '' }));
+
+    expect(mockedGetDoc).not.toHaveBeenCalled();
+    expect(mockedAddDoc).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getSharedGameById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('strips owner userId and userEmail from the public payload', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({
+        userId: 'owner-1',
+        userEmail: 'owner@example.com',
+        isPublic: true,
+        date: '2026-08-17',
+        currentInning: 5,
+      }),
+    });
+
+    const game = await getSharedGameById('game-1');
+
+    expect(game).not.toBeNull();
+    expect(game).not.toHaveProperty('userId');
+    expect(game).not.toHaveProperty('userEmail');
+    expect(game?.id).toBe('game-1');
+    expect(game?.date).toBe('2026-08-17');
+  });
+
+  it('rejects when the game is not public', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({ userId: 'owner-1', isPublic: false }),
+    });
+
+    await expect(getSharedGameById('game-1')).rejects.toThrow(
+      'この試合データは公開されていません'
+    );
+  });
+});

--- a/src/firebase/gameService.ts
+++ b/src/firebase/gameService.ts
@@ -17,6 +17,15 @@ import { getCurrentUser } from './authService';
 
 const GAMES_COLLECTION = 'games';
 
+// 所有権検証付きで既存の試合データを取得（不存在・他人のデータはエラー）
+const requireOwnedGame = async (gameId: string): Promise<Game> => {
+  const game = await getGameById(gameId);
+  if (!game) {
+    throw new Error('データが見つかりません');
+  }
+  return game;
+};
+
 // 試合データを保存
 export const saveGame = async (game: Game): Promise<string> => {
   try {
@@ -53,10 +62,7 @@ export const saveGame = async (game: Game): Promise<string> => {
 
     if (game.id) {
       // 既存のドキュメントを所有権検証してから更新
-      const existing = await getGameById(game.id);
-      if (!existing) {
-        throw new Error('データが見つかりません');
-      }
+      await requireOwnedGame(game.id);
 
       // 既存のドキュメントを更新
       docRef = doc(db, GAMES_COLLECTION, game.id);
@@ -213,10 +219,7 @@ export const getSharedGameById = async (
 export const deleteGame = async (gameId: string): Promise<void> => {
   try {
     // 権限チェック
-    const game = await getGameById(gameId);
-    if (!game) {
-      throw new Error('データが見つかりません');
-    }
+    await requireOwnedGame(gameId);
 
     const docRef = doc(db, GAMES_COLLECTION, gameId);
     await deleteDoc(docRef);
@@ -239,10 +242,7 @@ export const updateGamePublicStatus = async (
     }
 
     // 権限チェック（自分のデータかどうか）
-    const game = await getGameById(gameId);
-    if (!game) {
-      throw new Error('データが見つかりません');
-    }
+    await requireOwnedGame(gameId);
 
     const docRef = doc(db, GAMES_COLLECTION, gameId);
     await updateDoc(docRef, {

--- a/src/firebase/gameService.ts
+++ b/src/firebase/gameService.ts
@@ -52,11 +52,18 @@ export const saveGame = async (game: Game): Promise<string> => {
     let docRef;
 
     if (game.id) {
+      // 既存のドキュメントを所有権検証してから更新
+      const existing = await getGameById(game.id);
+      if (!existing) {
+        throw new Error('データが見つかりません');
+      }
+
       // 既存のドキュメントを更新
       docRef = doc(db, GAMES_COLLECTION, game.id);
-      // createdAtを削除して更新用のオブジェクトを作成（作成日時は維持する）
+      // 作成日時とドキュメントIDは更新対象から除外（作成日時は維持、IDはフィールドとして保存しない）
       const updateData = { ...gameToSave };
-      delete updateData.createdAt; // createdAtフィールドは更新しない
+      delete updateData.id;
+      delete updateData.createdAt;
       await updateDoc(docRef, updateData);
       console.log('Game updated successfully with ID:', game.id);
       return game.id;
@@ -186,7 +193,12 @@ export const getSharedGameById = async (
         throw new Error('この試合データは公開されていません');
       }
 
-      return { ...data, id: docSnap.id };
+      // 公開ペイロードから所有者の個人情報を除去する
+      const publicData = { ...data };
+      delete publicData.userId;
+      delete publicData.userEmail;
+
+      return { ...publicData, id: docSnap.id };
     } else {
       console.error('Game not found:', gameId);
       return null;


### PR DESCRIPTION
## 概要

Issue #193 に対応し、`src/firebase/gameService.ts` の認可・PII 問題を修正します。

## 変更内容

### IDOR: saveGame 更新パスの所有権チェック (critical)
- `game.id` がある場合、`updateDoc` の前に `getGameById` 経由の所有権検証を追加。`getGameById` は他人のデータで `このデータにアクセスする権限がありません` を throw し、不存在時は null を返すため `データが見つかりません` で fail-closed
- `deleteGame` / `updateGamePublicStatus` と一貫した検証経路に統一

### updateData から `id` / `createdAt` 除外
- 従来 `gameClone.id` が `updateData` に spread されドキュメント ID がフィールドとして冗長保存されていたため `delete updateData.id` を追加
- `createdAt` は従来どおり更新対象から除外（作成日時を維持）

### PII 漏洩: getSharedGameById (high)
- 公開ゲームのペイロードから所有者の `userId` / `userEmail` を除去して返却（`delete publicData.userId` / `delete publicData.userEmail`）

### TOCTOU: firestore.rules の確認 (medium)
- `firestore.rules` は games / teams とも `allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;` を既に強制しており、**ルールの変更は不要**と確認しました（WORKFLOW の「ルールが最終防衛線」を満たす）。クライアント側チェックは補助として維持
- ルール検証はレビューによる確認のみ（エミュレータ環境は本環境になし）

## テスト

新規 `src/firebase/__tests__/gameService.test.ts`（6 ケース、Red → Green で実施）:

- saveGame 更新パス: 他人のゲーム → reject + updateDoc 未呼び出し
- saveGame 更新パス: 不存在 → reject + updateDoc 未呼び出し
- saveGame 更新パス: 所有者 → updateDoc の payload に `id` / `createdAt` を含まない
- saveGame 新規パス: 所有権 lookup なしで addDoc
- getSharedGameById: `userId` / `userEmail` 除去を保持
- getSharedGameById: 非公開 → reject

## 実行したテスト

- `npm run ci:local`（prettier / lint / tsc / test:ci 19 スイート 120 テスト / build 全通過）
- エミュレータでの rules 検証は未実施（環境なし）— レビューで rules 既存記載を確認済み

## 影響範囲

- UI 変更: なし
- Firestore スキーマ: 変更なし（更新時 `id` フィールドを書かなくなるのみ。既存データの `id` フィールドは残るが読み取り側は `doc.id` を優先）
- セキュリティルール: 変更なし（既存の所有権強制を確認）

Closes #193