### PR TITLE
fix(firebase): strip protected team fields and run player ops in transactions

### DIFF
--- a/src/firebase/__tests__/teamService.test.ts
+++ b/src/firebase/__tests__/teamService.test.ts
@@ -1,0 +1,191 @@
+import {
+  getDoc,
+  updateDoc,
+  runTransaction,
+  doc as docFn,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { PlayerSetting, TeamSetting } from '../../types';
+import { getCurrentUser } from '../authService';
+import {
+  updateTeam,
+  addPlayerToTeam,
+  removePlayerFromTeam,
+  updatePlayerInTeam,
+} from '../teamService';
+
+const mockTransaction = { get: jest.fn(), update: jest.fn() };
+
+// jsdom 環境には Web Crypto のグローバルがないためスタブする
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'generated-player-id' },
+  configurable: true,
+  writable: true,
+});
+
+// react-scripts の jest 設定は resetMocks: true のため、
+// 実装はモジュールファクトリではなく beforeEach で設定する
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  getDocs: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  query: jest.fn(),
+  orderBy: jest.fn(),
+  updateDoc: jest.fn(),
+  deleteDoc: jest.fn(),
+  serverTimestamp: jest.fn(),
+  where: jest.fn(),
+  runTransaction: jest.fn(),
+}));
+
+jest.mock('../config', () => ({ db: {} }));
+
+jest.mock('../authService', () => ({ getCurrentUser: jest.fn() }));
+
+const mockedGetDoc = getDoc as jest.Mock;
+const mockedUpdateDoc = updateDoc as jest.Mock;
+const mockedRunTransaction = runTransaction as jest.Mock;
+const mockedDoc = docFn as jest.Mock;
+const mockedServerTimestamp = serverTimestamp as jest.Mock;
+const mockedGetCurrentUser = getCurrentUser as jest.Mock;
+
+const makePlayer = (id: string, name: string): PlayerSetting => ({
+  id,
+  name,
+  number: '1',
+  position: '投',
+  createdAt: '2026-01-01T00:00:00.000Z',
+});
+
+const ownTeamDoc = () => ({
+  exists: () => true,
+  id: 'team-1',
+  data: () =>
+    ({
+      name: 'マイチーム',
+      players: [makePlayer('p1', '山田'), makePlayer('p2', '鈴木')],
+      userId: 'user-1',
+      userEmail: 'me@example.com',
+      createdAt: 'CREATED_AT',
+    }) as TeamSetting,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetCurrentUser.mockReturnValue({
+    uid: 'user-1',
+    email: 'me@example.com',
+  });
+  mockedDoc.mockReturnValue({});
+  mockedServerTimestamp.mockReturnValue('SERVER_TIMESTAMP');
+  mockedRunTransaction.mockImplementation((_db, callback) =>
+    callback(mockTransaction)
+  );
+  mockTransaction.get.mockResolvedValue(ownTeamDoc());
+});
+
+describe('updateTeam', () => {
+  it('strips protected fields from the update payload', async () => {
+    mockedGetDoc.mockResolvedValue(ownTeamDoc());
+
+    await updateTeam('team-1', {
+      name: '新しい名前',
+      id: 'evil-id',
+      userId: 'evil-user',
+      userEmail: 'evil@example.com',
+      createdAt: 'evil-created-at',
+    } as Partial<TeamSetting>);
+
+    expect(mockedUpdateDoc).toHaveBeenCalledTimes(1);
+    const payload = mockedUpdateDoc.mock.calls[0][1];
+    expect(payload).not.toHaveProperty('id');
+    expect(payload).not.toHaveProperty('userId');
+    expect(payload).not.toHaveProperty('userEmail');
+    expect(payload).not.toHaveProperty('createdAt');
+    expect(payload.name).toBe('新しい名前');
+    expect(payload.updatedAt).toBe('SERVER_TIMESTAMP');
+  });
+
+  it('rejects when the team belongs to another user', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'team-1',
+      data: () => ({ ...ownTeamDoc().data(), userId: 'someone-else' }),
+    });
+
+    await expect(updateTeam('team-1', { name: 'x' })).rejects.toThrow(
+      'このデータを編集する権限がありません'
+    );
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+  });
+});
+
+describe('addPlayerToTeam', () => {
+  it('appends the player inside a single transaction', async () => {
+    await addPlayerToTeam('team-1', {
+      name: '佐藤',
+      number: '9',
+      position: '右',
+    });
+
+    expect(mockedRunTransaction).toHaveBeenCalledTimes(1);
+    expect(mockedGetDoc).not.toHaveBeenCalled();
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+
+    const payload = mockTransaction.update.mock.calls[0][1];
+    expect(payload.players).toHaveLength(3);
+    expect(payload.players[2]).toMatchObject({
+      name: '佐藤',
+      number: '9',
+      position: '右',
+    });
+    expect(payload.players[2].id).toBeDefined();
+  });
+
+  it('rejects inside the transaction when the team belongs to another user', async () => {
+    mockTransaction.get.mockResolvedValue({
+      exists: () => true,
+      id: 'team-1',
+      data: () => ({ ...ownTeamDoc().data(), userId: 'someone-else' }),
+    });
+
+    await expect(
+      addPlayerToTeam('team-1', { name: '佐藤', number: '9', position: '右' })
+    ).rejects.toThrow('このデータを編集する権限がありません');
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('removePlayerFromTeam', () => {
+  it('removes the player inside a single transaction', async () => {
+    await removePlayerFromTeam('team-1', 'p1');
+
+    expect(mockedRunTransaction).toHaveBeenCalledTimes(1);
+    expect(mockedGetDoc).not.toHaveBeenCalled();
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+
+    const payload = mockTransaction.update.mock.calls[0][1];
+    expect(payload.players).toHaveLength(1);
+    expect(payload.players[0].id).toBe('p2');
+  });
+});
+
+describe('updatePlayerInTeam', () => {
+  it('merges player data inside a single transaction', async () => {
+    await updatePlayerInTeam('team-1', 'p1', { name: '山田太郎' });
+
+    expect(mockedRunTransaction).toHaveBeenCalledTimes(1);
+    expect(mockedGetDoc).not.toHaveBeenCalled();
+    expect(mockedUpdateDoc).not.toHaveBeenCalled();
+
+    const payload = mockTransaction.update.mock.calls[0][1];
+    expect(payload.players[0]).toMatchObject({
+      id: 'p1',
+      name: '山田太郎',
+      position: '投',
+    });
+    expect(payload.players[1].name).toBe('鈴木');
+  });
+});

--- a/src/firebase/teamService.ts
+++ b/src/firebase/teamService.ts
@@ -8,6 +8,7 @@ import {
   orderBy,
   updateDoc,
   deleteDoc,
+  runTransaction,
   serverTimestamp,
   where,
 } from 'firebase/firestore';
@@ -16,6 +17,23 @@ import { TeamSetting, PlayerSetting } from '../types';
 import { getCurrentUser } from './authService';
 
 const TEAMS_COLLECTION = 'teams';
+
+// 所有権検証付きでトランザクションスナップショットからチームデータを取得
+const requireOwnedTeamFromSnapshot = (
+  teamSnap: { exists: () => boolean; data: () => unknown },
+  user: { uid: string }
+): TeamSetting => {
+  if (!teamSnap.exists()) {
+    throw new Error('チームデータが見つかりません');
+  }
+
+  const team = teamSnap.data() as TeamSetting;
+  if (team.userId !== user.uid) {
+    throw new Error('このデータを編集する権限がありません');
+  }
+
+  return team;
+};
 
 // チームデータを保存（新規作成）
 export const createTeam = async (
@@ -61,20 +79,18 @@ export const updateTeam = async (
     }
 
     // 権限チェック
-    const team = await getTeamById(teamId);
-    if (!team) {
-      throw new Error('チームデータが見つかりません');
-    }
+    const teamSnap = await getDoc(doc(db, TEAMS_COLLECTION, teamId));
+    requireOwnedTeamFromSnapshot(teamSnap, user);
 
-    if (team.userId !== user.uid) {
-      throw new Error('このデータを編集する権限がありません');
-    }
-
-    // 更新データを準備
+    // 更新データを準備（保護フィールドは上書きしない）
     const updateData = {
       ...teamData,
       updatedAt: serverTimestamp(),
-    };
+    } as Record<string, unknown>;
+    delete updateData.id;
+    delete updateData.userId;
+    delete updateData.userEmail;
+    delete updateData.createdAt;
 
     // 更新処理
     const teamRef = doc(db, TEAMS_COLLECTION, teamId);
@@ -172,28 +188,25 @@ export const addPlayerToTeam = async (
       throw new Error('ログインが必要です');
     }
 
-    // チームを取得して権限チェック
-    const team = await getTeamById(teamId);
-    if (!team) {
-      throw new Error('チームデータが見つかりません');
-    }
+    // トランザクション内で読み取り・権限チェック・書き込みを一貫させる
+    const teamRef = doc(db, TEAMS_COLLECTION, teamId);
+    await runTransaction(db, async (transaction) => {
+      const teamSnap = await transaction.get(teamRef);
+      const team = requireOwnedTeamFromSnapshot(teamSnap, user);
 
-    if (team.userId !== user.uid) {
-      throw new Error('このデータを編集する権限がありません');
-    }
+      // 新しい選手データを準備
+      const newPlayer: PlayerSetting = {
+        ...player,
+        id: crypto.randomUUID(), // クライアントサイドでIDを生成
+        createdAt: new Date().toISOString(), // サーバータイムスタンプの代わりに現在時刻を文字列で保存
+      };
 
-    // 新しい選手データを準備
-    const newPlayer: PlayerSetting = {
-      ...player,
-      id: crypto.randomUUID(), // クライアントサイドでIDを生成
-      createdAt: new Date().toISOString(), // サーバータイムスタンプの代わりに現在時刻を文字列で保存
-    };
-
-    // 既存の選手リストに追加
-    const updatedPlayers = [...team.players, newPlayer];
-
-    // チームデータを更新
-    await updateTeam(teamId, { players: updatedPlayers });
+      // 既存の選手リストに追加
+      transaction.update(teamRef, {
+        players: [...team.players, newPlayer],
+        updatedAt: serverTimestamp(),
+      });
+    });
     console.log('Player added to team successfully');
   } catch (error) {
     console.error('Error adding player to team:', error);
@@ -212,23 +225,22 @@ export const removePlayerFromTeam = async (
       throw new Error('ログインが必要です');
     }
 
-    // チームを取得して権限チェック
-    const team = await getTeamById(teamId);
-    if (!team) {
-      throw new Error('チームデータが見つかりません');
-    }
+    // トランザクション内で読み取り・権限チェック・書き込みを一貫させる
+    const teamRef = doc(db, TEAMS_COLLECTION, teamId);
+    await runTransaction(db, async (transaction) => {
+      const teamSnap = await transaction.get(teamRef);
+      const team = requireOwnedTeamFromSnapshot(teamSnap, user);
 
-    if (team.userId !== user.uid) {
-      throw new Error('このデータを編集する権限がありません');
-    }
+      // 選手を除外
+      const updatedPlayers = team.players.filter(
+        (player) => player.id !== playerId
+      );
 
-    // 選手を除外
-    const updatedPlayers = team.players.filter(
-      (player) => player.id !== playerId
-    );
-
-    // チームデータを更新
-    await updateTeam(teamId, { players: updatedPlayers });
+      transaction.update(teamRef, {
+        players: updatedPlayers,
+        updatedAt: serverTimestamp(),
+      });
+    });
     console.log('Player removed from team successfully');
   } catch (error) {
     console.error('Error removing player from team:', error);
@@ -248,26 +260,25 @@ export const updatePlayerInTeam = async (
       throw new Error('ログインが必要です');
     }
 
-    // チームを取得して権限チェック
-    const team = await getTeamById(teamId);
-    if (!team) {
-      throw new Error('チームデータが見つかりません');
-    }
+    // トランザクション内で読み取り・権限チェック・書き込みを一貫させる
+    const teamRef = doc(db, TEAMS_COLLECTION, teamId);
+    await runTransaction(db, async (transaction) => {
+      const teamSnap = await transaction.get(teamRef);
+      const team = requireOwnedTeamFromSnapshot(teamSnap, user);
 
-    if (team.userId !== user.uid) {
-      throw new Error('このデータを編集する権限がありません');
-    }
+      // 選手データを更新
+      const updatedPlayers = team.players.map((player) => {
+        if (player.id === playerId) {
+          return { ...player, ...playerData };
+        }
+        return player;
+      });
 
-    // 選手データを更新
-    const updatedPlayers = team.players.map((player) => {
-      if (player.id === playerId) {
-        return { ...player, ...playerData };
-      }
-      return player;
+      transaction.update(teamRef, {
+        players: updatedPlayers,
+        updatedAt: serverTimestamp(),
+      });
     });
-
-    // チームデータを更新
-    await updateTeam(teamId, { players: updatedPlayers });
     console.log('Player updated in team successfully');
   } catch (error) {
     console.error('Error updating player in team:', error);


### PR DESCRIPTION
## 概要

Issue #194 に対応し、`src/firebase/teamService.ts` の保護フィールド書き換えと players 配列のロストアップデートレースを修正します。

## 変更内容

### 保護フィールドの注入防止 (security: high)
- `updateTeam` が `id` / `userId` / `userEmail` / `createdAt` を更新ペイロードから除外。呼び出し元や古い UI 状態が所有権検証後にオーナーを書き換える経路を遮断
- ルール側は既存ドキュメントの `userId` のみ検証し incoming フィールドを検証しないため、クライアント側ストリップが主要防御になる（Issue 記載のとおり）

### players 配列のロストアップデートレース (bug: critical)
- `addPlayerToTeam` / `removePlayerFromTeam` / `updatePlayerInTeam` を `runTransaction` 内で read → 所有権検証 → write に変更。並行操作で2番目の書き込みが1番目を上書きし選手が消失・復活するレースを解消
- 所有権検証はトランザクションスナップショットに対して実行（`requireOwnedTeamFromSnapshot` ヘルパーで3操作＋`updateTeam` で共用）

### 二重 getDoc の解消
- players 系操作が `getTeamById` + `updateTeam`（内部で再度 `getDoc`）を呼ぶ構造を廃止し、トランザクションの1回の読み取りに統合。読取りコストとレース窓を半減

## テスト

新規 `src/firebase/__tests__/teamService.test.ts`（6 ケース、Red → Green で実施）:

- updateTeam: 保護フィールド（id/userId/userEmail/createdAt）が payload から除外される
- updateTeam: 他人のチーム → reject + updateDoc 未呼び出し
- addPlayerToTeam: 単一トランザクションで追記（getDoc/updateDoc 未使用）
- addPlayerToTeam: トランザクション内で他人のチーム → reject + transaction.update 未呼び出し
- removePlayerFromTeam: 単一トランザクションで除外
- updatePlayerInTeam: 単一トランザクションでマージ

なお react-scripts の jest 設定は `resetMocks: true` のため、モック実装はモジュールファクトリでなく `beforeEach` で設定しています（直接 `npx jest` と `react-scripts test` の挙動差に対応）。

## 実行したテスト

- `npm run ci:local`（prettier / lint / tsc / test:ci 19 スイート 120 テスト / build 全通過）
- エミュレータでの実トランザクション検証は未実施（環境なし）— モックによる契約検証のみ

## 影響範囲

- UI 変更: なし
- Firestore スキーマ: 変更なし（`players` 配列・`updatedAt` のみ書き込み）
- セキュリティルール: 変更なし

Closes #194