### PR TITLE
fix: .firebaserc の staging エイリアスを専用プロジェクトに向けて production エイリアスを追加

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,7 +1,8 @@
 {
   "projects": {
     "default": "baseball-score-18c48",
-    "staging": "baseball-score-18c48"
+    "production": "baseball-score-18c48",
+    "staging": "baseball-score-staging"
   },
   "targets": {},
   "etags": {}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 ## デプロイ方法
 
+デプロイ先は `.firebaserc` のエイリアス（`production` / `staging`）で切り替えます。
+対象を明示するため、常に `--project` にプロジェクト ID を指定してください。
+
 1. ビルドを作成します
 
 ```
@@ -79,7 +82,11 @@ npm run build
 2. Firebase にデプロイします
 
 ```
-firebase deploy
+# 本番（baseball-score-18c48）
+firebase deploy --project baseball-score-18c48
+
+# ステージング（baseball-score-staging）
+firebase deploy --project baseball-score-staging
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 デプロイ先は `.firebaserc` のエイリアス（`production` / `staging`）で切り替えます。
 対象を明示するため、常に `--project` にプロジェクト ID を指定してください。
-エイリアスを指定しない `firebase deploy` は `default` エイリアス（= 本番プロジェクト）に
-デプロイされるため注意してください。
+`--project` を省略した `firebase` CLI コマンド（`firebase deploy`、
+`firebase hosting:disable` など）は `default` エイリアス（= 本番プロジェクト）を
+対象にするため注意してください。
 
 1. ビルドを作成します
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 デプロイ先は `.firebaserc` のエイリアス（`production` / `staging`）で切り替えます。
 対象を明示するため、常に `--project` にプロジェクト ID を指定してください。
+エイリアスを指定しない `firebase deploy` は `default` エイリアス（= 本番プロジェクト）に
+デプロイされるため注意してください。
 
 1. ビルドを作成します
 


### PR DESCRIPTION
## 変更内容

- `.firebaserc` の `staging` エイリアスを、従来の本番プロジェクト `baseball-score-18c48` から専用の staging プロジェクト `baseball-score-staging` に変更
- 既存本番プロジェクトに対する明示的な `production` エイリアスを追加（`default` は `production` と同一のまま）
- staging プロジェクト `baseball-score-staging` を Firebase CLI（`firebase projects:create`、Spark プラン・課金なし）で新規作成済み
- README のデプロイ手順に `--project` による明示的なプロジェクト指定（本番 / ステージング）を追記

## 背景

`firebase deploy --project staging` が実際には本番プロジェクトを mutate する状態だったため、ステージング環境として機能していなかった。

Closes #195

## 受け入れ基準

- [x] staging エイリアスが本番と別のプロジェクトを指す（`baseball-score-staging`）
- [x] production エイリアスが明示的に定義される

## 検証

- `node` による JSON 検証: `production=baseball-score-18c48` / `staging=baseball-score-staging` / `staging !== production`
- `firebase projects:list --json` で `baseball-score-staging` の存在を確認
- 本変更はアプリコード（`src/`）に触れないため `npm run ci:local` は対象外（YAML/TS 実装の変更なし）

## 備考（スコープ外）

- staging プロジェクトへの Firestore / Hosting の初回デプロイと `firestore.rules` の適用は別タスク
- `REACT_APP_*` 環境変数は staging 用の値を `.env` 系で切り替える必要があるが、本 Issue のスコープ外

## Firestore スキーマ・セキュリティルールへの影響

なし（`.firebaserc` と README のみの変更）