### PR TITLE
fix: GitHub Actions のサプライチェーンハードニング（SHA pin・権限・timeout・concurrency）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
             const failed = Object.entries(needs).filter(([, n]) => n.result !== "success");
             if (failed.length > 0) {
               console.error("❌ Upstream gate(s) did not succeed: " +
-                failed.map(([job, n]) => `${job}=${n.result}`).join(", "));
+                failed.map(([job, n]) => job + "=" + n.result).join(", "));
               process.exit(1);
             }
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,17 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
-env:
-  NODE_VERSION_MATRIX: '["16", "18", "20"]'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # 基本的なlintとタイプチェック
   lint-and-type-check:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -45,6 +46,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -66,7 +68,9 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16, 18, 20]
 
@@ -90,6 +94,7 @@ jobs:
   coverage:
     name: Generate Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [test]
 
     steps:
@@ -122,7 +127,7 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info
           flags: unittests
@@ -142,6 +147,7 @@ jobs:
   build:
     name: Build Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint-and-type-check]
 
     steps:
@@ -182,10 +188,11 @@ jobs:
           retention-days: 7
 
   # デプロイメント準備チェック（実質的な品質ゲート）
+  # test:ci / build の再実行はせず、各ジョブの成果物を再利用する
   deployment-check:
     name: Deployment Readiness
     runs-on: ubuntu-latest
-    needs: [build, security-audit]
+    needs: [lint-and-type-check, test, coverage, build, security-audit]
     timeout-minutes: 30
     env:
       COVERAGE_THRESHOLD: 30
@@ -199,28 +206,18 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: '20'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage
 
-      - name: Run tests with coverage
-        run: npm run test:ci
-
-      - name: Debug - List files after coverage run
-        run: |
-          echo "--- Listing files in workspace root ---"
-          ls -la
-          echo "--- Checking for coverage directory ---"
-          if [ -d "coverage" ]; then
-            echo "Coverage directory exists. Listing contents:"
-            ls -laR coverage
-          else
-            echo "Coverage directory NOT found."
-          fi
-
-      - name: Build project
-        run: npm run build
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: build-files
+          path: build
 
       - name: Check test coverage threshold
         id: coverage
@@ -230,22 +227,15 @@ jobs:
         id: bundle-size
         run: node scripts/check-bundle-size.js
 
-      - name: Verify TypeScript compilation
-        id: typecheck
-        run: npx tsc --noEmit
-
-      - name: Check for security vulnerabilities
-        id: audit
-        run: npm audit --audit-level=high --production
-
       - name: Quality gate summary
         if: ${{ !cancelled() }}
         run: |
           echo ""
           echo "📊 Quality Gate Report"
           echo "═══════════════════════════════════════"
-          echo "Test Coverage (>=${COVERAGE_THRESHOLD}%): ${{ steps.coverage.outcome || 'skipped' }}"
+          echo "Test (Node matrix): ${{ needs.test.result }}"
+          echo "Coverage (>=${COVERAGE_THRESHOLD}%): ${{ steps.coverage.outcome || 'skipped' }}"
           echo "Bundle Size (<=${MAX_BUNDLE_SIZE_MB}MB): ${{ steps.bundle-size.outcome || 'skipped' }}"
-          echo "TypeScript: ${{ steps.typecheck.outcome || 'skipped' }}"
-          echo "Security Audit: ${{ steps.audit.outcome || 'skipped' }}"
+          echo "TypeScript: ${{ needs.lint-and-type-check.result }}"
+          echo "Security Audit: ${{ needs.security-audit.result }}"
           echo "═══════════════════════════════════════"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # 同一PRへの連続pushのみ先行runをキャンセル。main/developへのpushは完了まで実行する
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # 基本的なlintとタイプチェック
@@ -189,10 +190,12 @@ jobs:
 
   # デプロイメント準備チェック（実質的な品質ゲート）
   # test:ci / build の再実行はせず、各ジョブの成果物を再利用する
+  # !cancelled() で上流ジョブ失敗時もサマリーを出力し、最終ステップでジョブを失敗させる
   deployment-check:
     name: Deployment Readiness
     runs-on: ubuntu-latest
     needs: [lint-and-type-check, test, coverage, build, security-audit]
+    if: ${{ !cancelled() }}
     timeout-minutes: 30
     env:
       COVERAGE_THRESHOLD: 30
@@ -208,12 +211,14 @@ jobs:
           node-version: '20'
 
       - name: Download coverage artifacts
+        if: ${{ needs.coverage.result == 'success' }}
         uses: actions/download-artifact@v7
         with:
           name: coverage-report
           path: coverage
 
       - name: Download build artifacts
+        if: ${{ needs.build.result == 'success' }}
         uses: actions/download-artifact@v7
         with:
           name: build-files
@@ -221,10 +226,12 @@ jobs:
 
       - name: Check test coverage threshold
         id: coverage
+        if: ${{ needs.coverage.result == 'success' }}
         run: node scripts/check-coverage.js
 
       - name: Check bundle size
         id: bundle-size
+        if: ${{ needs.build.result == 'success' }}
         run: node scripts/check-bundle-size.js
 
       - name: Quality gate summary
@@ -239,3 +246,14 @@ jobs:
           echo "TypeScript: ${{ needs.lint-and-type-check.result }}"
           echo "Security Audit: ${{ needs.security-audit.result }}"
           echo "═══════════════════════════════════════"
+
+      - name: Fail if any upstream gate failed
+        if: ${{ !cancelled() }}
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          for result in $results; do
+            if [ "$result" != "success" ]; then
+              echo "❌ Upstream gate did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,11 +249,15 @@ jobs:
 
       - name: Fail if any upstream gate failed
         if: ${{ !cancelled() }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
         run: |
-          results="${{ join(needs.*.result, ' ') }}"
-          for result in $results; do
-            if [ "$result" != "success" ]; then
-              echo "❌ Upstream gate did not succeed: $result"
-              exit 1
-            fi
-          done
+          node -e '
+            const needs = JSON.parse(process.env.NEEDS_CONTEXT);
+            const failed = Object.entries(needs).filter(([, n]) => n.result !== "success");
+            if (failed.length > 0) {
+              console.error("❌ Upstream gate(s) did not succeed: " +
+                failed.map(([job, n]) => `${job}=${n.result}`).join(", "));
+              process.exit(1);
+            }
+          '

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,15 @@ on:
   schedule:
     - cron: '0 6 * * 1' # 毎週月曜日 6:00 UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -27,7 +32,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -45,6 +50,6 @@ jobs:
         run: npm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,9 @@ on:
     - cron: '0 6 * * 1' # 毎週月曜日 6:00 UTC
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # 同一PRへの連続pushのみ先行runをキャンセル。main/developへのpushとscheduled runは完了まで実行する
+  # scheduled run はユニークグループで必ず実行。それ以外は ref 単位とし、
+  # 同一PRへの連続pushのみ先行runをキャンセル（main/developへのpushは完了まで実行）
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # 同一PRへの連続pushのみ先行runをキャンセル。main/developへのpushとscheduled runは完了まで実行する
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -10,8 +10,9 @@ on:
     - cron: '0 0 * * 1'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # 同一PRへの連続pushのみ先行runをキャンセル。mainへのpushとscheduled runは完了まで実行する
+  # scheduled run はユニークグループで必ず実行。それ以外は ref 単位とし、
+  # 同一PRへの連続pushのみ先行runをキャンセル（mainへのpushは完了まで実行）
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -11,7 +11,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # 同一PRへの連続pushのみ先行runをキャンセル。mainへのpushとscheduled runは完了まで実行する
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # CodeQL セキュリティ分析

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -9,11 +9,16 @@ on:
     # 毎週月曜日の午前0時（UTC）に実行
     - cron: '0 0 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # CodeQL セキュリティ分析
   codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read
@@ -24,16 +29,16 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:javascript'
 
@@ -41,6 +46,9 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
 
     steps:
@@ -48,7 +56,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
 
@@ -56,6 +64,9 @@ jobs:
   sast-scan:
     name: SAST Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 変更内容

### セキュリティ (high)
- 第三方 action をコミット SHA に pin 化（タグハイジャック対策）
  - `github/codeql-action/{init,autobuild,analyze}` → `ff2f1c62` (= v4.37.7)
  - `codecov/codecov-action` → `fb8b3582` (= v7.0.0)
  - `actions/dependency-review-action` → `a1d282b3` (= v5.0.0)
- ci.yml トップレベルの過剰な `actions: write` を削除し `contents: read` のみに
- quality-gate.yml の dependency-review / sast-scan ジョブに `permissions: contents: read` を追加

### 運用 (medium)
- 全ワークフロー（ci / quality-gate / codeql）に `concurrency` を追加
  - `cancel-in-progress` は `pull_request` イベント時のみ有効化（Issue の趣旨である「同一 PR への連続 push」の重複排除のみ行い、main/develop への push は完了まで実行）
  - `schedule` イベントはユニークグループ（`run_id`）を与え、週次スキャンが pending 中の上書きで欠落しないようにする
- 全ジョブに `timeout-minutes` を設定（ハング時の 360 分既定実行を防止）
  - ci.yml: lint 15 / audit 15 / test 30 / coverage 30 / build 20 / deployment-check 30（既存）
  - quality-gate.yml: codeql 30 / dependency-review 10 / sast 20
  - codeql.yml: analyze 30
- 未参照の `NODE_VERSION_MATRIX` env を削除
- test matrix に `fail-fast: false` を設定（バージョン固有の失敗判別）
- deployment-check ジョブが `npm ci` + `test:ci` + `build` を再実行しパイプラインを倍加させていたのを、`needs: [lint-and-type-check, test, coverage, build, security-audit]` + artifact 再利用（`actions/download-artifact@v7`）に変更
  - 型チェックは lint-and-type-check、監査は security-audit ジョブで既に実施されており、deployment-check はカバレッジ閾値とバンドルサイズのゲート + 集約サマリーに専念
  - 上流ジョブ失敗時もサマリーが出力されるよう job レベル `if: !cancelled()` を付与し、最終ステップで上流結果が全て success でなければジョブを失敗させる（ゲート強度は従来と同等）

## アクションタグの確認

`gh api repos/<owner>/<repo>/git/ref/tags/<tag>` および実行ログで確認:
- `actions/checkout@v7` / `actions/setup-node@v7` / `actions/upload-artifact@v7` / `actions/download-artifact@v7`: 実在（first-party のためタグ参照のまま）
- `github/codeql-action` の浮動タグは `v4` のみ実在（v4 = v4.37.7 = `ff2f1c62`）
- `actions/dependency-review-action@v5` は Git タグとしては実在しないが、GitHub Actions の解決では v5.0.0（`a1d282b3`）に解決されることを PR #221 の実行ログで確認。SHA pin 化により mutable な解決を固定

Closes #196

## 受け入れ基準

- [x] 第三方 action を SHA pin 化
- [x] `actions: write` 削除、各ジョブに最小権限 permissions
- [x] 全ジョブに timeout-minutes、全 workflow に concurrency
- [x] デッド env 削除、deployment-check の重複解消

## 検証

- `actionlint`（全ワークフローファイル、各修正後に再実行）: パス
- `js-yaml` による YAML 構文解析: パス
- deployment-check 最終ゲートの node スクリプトをローカルで検証（全 success / failure・skipped 混在の両ケースで期待する終了コード）
- 実 GitHub Actions 実行は本 PR の CI で確認（deployment-check の artifact 再利用を含む）
- アプリコード（`src/`）の変更がないため `npm run ci:local` は対象外

## Firestore スキーマ・セキュリティルールへの影響

なし（`.github/workflows/` のみの変更）