### PR TITLE
fix: unify score and batting calculations

### DIFF
--- a/src/components/AtBatForm.tsx
+++ b/src/components/AtBatForm.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mui/icons-material';
 import { HitResult, Player, AtBat } from '../types';
 import { v4 as uuidv4 } from 'uuid';
+import { HIT_RESULTS } from '../services/ScoreCalculator';
 
 // カスタムカラー定義
 const customColors = {
@@ -32,7 +33,6 @@ const customColors = {
 
 // 結果に応じた色を返す関数
 const getResultColor = (result: HitResult): string => {
-  const hitPatterns = ['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR'];
   const outPatterns = [
     'GO_P',
     'GO_C',
@@ -53,7 +53,7 @@ const getResultColor = (result: HitResult): string => {
   ];
   const walkPatterns = ['BB', 'HBP'];
 
-  if (hitPatterns.includes(result)) {
+  if (HIT_RESULTS.includes(result)) {
     return customColors.hit;
   }
   if (outPatterns.includes(result)) {
@@ -138,7 +138,7 @@ const isOutResult = (result: HitResult): boolean => {
 const hitOptions = [
   {
     category: 'ヒット',
-    items: ['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR'] as HitResult[],
+    items: [...HIT_RESULTS],
   },
   {
     category: 'ゴロアウト',

--- a/src/components/AtBatHistory.tsx
+++ b/src/components/AtBatHistory.tsx
@@ -17,6 +17,7 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { AtBat, Player, HitResult, RunEvent, OutEvent } from '../types';
+import { SINGLE_RESULTS } from '../services/ScoreCalculator';
 
 interface AtBatHistoryProps {
   atBats: AtBat[];
@@ -122,7 +123,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
     result: HitResult
   ): 'success' | 'error' | 'warning' | 'default' | 'info' | 'secondary' => {
     // ヒット系
-    if (['IH', 'LH', 'CH', 'RH'].includes(result)) {
+    if (SINGLE_RESULTS.includes(result)) {
       return 'success';
     }
     // 長打系

--- a/src/components/AtBatSummaryTable.tsx
+++ b/src/components/AtBatSummaryTable.tsx
@@ -22,6 +22,11 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Team, AtBat, HitResult, OutEvent } from '../types';
+import {
+  HIT_RESULTS,
+  SINGLE_RESULTS,
+  ScoreCalculator,
+} from '../services/ScoreCalculator';
 
 interface AtBatSummaryTableProps {
   team: Team;
@@ -81,7 +86,7 @@ const customColors = {
 // 結果に応じた色を返す関数
 const getResultColor = (result: HitResult): string => {
   // ヒット系
-  if (['IH', 'LH', 'CH', 'RH'].includes(result)) {
+  if (SINGLE_RESULTS.includes(result)) {
     return customColors.hit;
   }
   // 二塁打
@@ -113,100 +118,11 @@ const getResultColor = (result: HitResult): string => {
 // 結果に応じたテキスト色を返す関数
 const getTextColor = (result: HitResult): string => {
   // ヒット系、長打系、ホームランは白文字
-  if (['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR'].includes(result)) {
+  if (HIT_RESULTS.includes(result)) {
     return '#FFFFFF';
   }
   // その他は黒文字
   return '#000000';
-};
-
-// 打撃成績を計算するヘルパー関数
-interface BattingStats {
-  atBats: number; // 打数
-  hits: number; // 安打数
-  rbis: number; // 打点
-  walks: number; // 四球/死球
-  singles: number; // 単打
-  doubles: number; // 二塁打
-  triples: number; // 三塁打
-  homeRuns: number; // ホームラン
-  battingAvg: number; // 打率
-  obp: number; // 出塁率
-  slg: number; // 長打率
-  ops: number; // OPS
-}
-
-// 選手の打撃成績を計算
-const calculateBattingStats = (playerAtBats: AtBat[]): BattingStats => {
-  const stats: BattingStats = {
-    atBats: 0,
-    hits: 0,
-    rbis: 0,
-    walks: 0,
-    singles: 0,
-    doubles: 0,
-    triples: 0,
-    homeRuns: 0,
-    battingAvg: 0,
-    obp: 0,
-    slg: 0,
-    ops: 0,
-  };
-
-  // 打点の合計
-  stats.rbis = playerAtBats.reduce((sum, atBat) => sum + (atBat.rbi || 0), 0);
-
-  // 打撃結果の集計
-  playerAtBats.forEach((atBat) => {
-    const result = atBat.result;
-
-    // 四球/死球はカウント
-    if (result === 'BB' || result === 'HBP') {
-      stats.walks++;
-      return;
-    }
-
-    // 犠打/犠飛はカウントしない
-    if (result === 'SAC' || result === 'SF') {
-      return;
-    }
-
-    // 打数にカウントするケース
-    stats.atBats++;
-
-    // 安打の種類に応じてカウント
-    if (['IH', 'LH', 'CH', 'RH'].includes(result)) {
-      stats.hits++;
-      stats.singles++;
-    } else if (result === '2B') {
-      stats.hits++;
-      stats.doubles++;
-    } else if (result === '3B') {
-      stats.hits++;
-      stats.triples++;
-    } else if (result === 'HR') {
-      stats.hits++;
-      stats.homeRuns++;
-    }
-  });
-
-  // 打率計算 (打数が0の場合は0)
-  stats.battingAvg = stats.atBats > 0 ? stats.hits / stats.atBats : 0;
-
-  // 出塁率計算 (打数+四球が0の場合は0)
-  const plateAppearances = stats.atBats + stats.walks;
-  stats.obp =
-    plateAppearances > 0 ? (stats.hits + stats.walks) / plateAppearances : 0;
-
-  // 長打率計算 (打数が0の場合は0)
-  const totalBases =
-    stats.singles + stats.doubles * 2 + stats.triples * 3 + stats.homeRuns * 4;
-  stats.slg = stats.atBats > 0 ? totalBases / stats.atBats : 0;
-
-  // OPS計算
-  stats.ops = stats.obp + stats.slg;
-
-  return stats;
 };
 
 // 打率などを表示するフォーマット関数
@@ -543,7 +459,7 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
 
         {sortedPlayers.map((player) => {
           const playerAtBats = getPlayerAllAtBats(player.id);
-          const stats = calculateBattingStats(playerAtBats);
+          const stats = ScoreCalculator.calculateBattingStats(playerAtBats);
 
           return (
             <Accordion key={player.id} sx={{ mb: 1 }}>
@@ -686,7 +602,7 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
           <TableBody>
             {sortedPlayers.map((player) => {
               const playerAtBats = getPlayerAllAtBats(player.id);
-              const stats = calculateBattingStats(playerAtBats);
+              const stats = ScoreCalculator.calculateBattingStats(playerAtBats);
 
               return (
                 <TableRow key={player.id}>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -13,22 +13,14 @@ import {
   Stack,
 } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
-import { Team, RunEvent, HitResult } from '../types';
+import { Team, RunEvent } from '../types';
+import { ScoreCalculator } from '../services/ScoreCalculator';
 
-const HIT_RESULT_SET = new Set<HitResult>([
-  'IH',
-  'LH',
-  'CH',
-  'RH',
-  '2B',
-  '3B',
-  'HR',
-] as HitResult[]);
 const countHits = (team: Team): number =>
-  team.atBats.filter((atBat) => HIT_RESULT_SET.has(atBat.result)).length;
+  ScoreCalculator.calculateHits(team.atBats);
 
 const countErrors = (team: Team): number =>
-  team.atBats.filter((atBat) => atBat.result === 'E').length;
+  ScoreCalculator.calculateErrors(team.atBats);
 
 interface ScoreBoardProps {
   homeTeam: Team;
@@ -57,53 +49,12 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
     [displayInnings]
   );
 
-  // 得点イベントから得点を計算
-  const calculateRunEventsScore = (inning: number, isTop: boolean): number => {
-    return runEvents
-      .filter((event) => event.inning === inning && event.isTop === isTop)
-      .reduce((total, event) => total + (event.runCount || 0), 0);
-  };
-
-  // チームの得点を計算
-  const calculateScore = (
-    team: Team,
-    inning: number,
-    isAwayTeam: boolean
-  ): number => {
-    // 打席結果からの得点
-    const atBatScore = team.atBats
-      .filter((atBat) => atBat.inning === inning)
-      .reduce((total, atBat) => total + (atBat.rbi || 0), 0);
-
-    // 得点イベントからの得点（先攻チームは表、後攻チームは裏）
-    const runEventScore = calculateRunEventsScore(inning, isAwayTeam);
-
-    return atBatScore + runEventScore;
-  };
-
-  // チームの合計得点を計算
-  const calculateTotalScore = (team: Team, isAwayTeam: boolean): number => {
-    // 全ての打席結果の打点を合計
-    const atBatTotal = team.atBats.reduce(
-      (total, atBat) => total + (atBat.rbi || 0),
-      0
-    );
-
-    // 全ての得点イベントを合計（イニングごとにフィルタリング）
-    const runEventTotal = runEvents
-      .filter((event) => event.isTop === isAwayTeam)
-      .reduce((total, event) => total + (event.runCount || 0), 0);
-
-    return atBatTotal + runEventTotal;
-  };
-
   // 合計得点を事前に計算してメモ化
   const totalScores = useMemo(
     () => ({
-      away: calculateTotalScore(awayTeam, true),
-      home: calculateTotalScore(homeTeam, false),
+      away: ScoreCalculator.calculateTotalScore(awayTeam, runEvents, true),
+      home: ScoreCalculator.calculateTotalScore(homeTeam, runEvents, false),
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [awayTeam, homeTeam, runEvents]
   );
 
@@ -345,7 +296,12 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                     ...(inning === currentInning ? highlightStyles : {}),
                   }}
                 >
-                  {calculateScore(awayTeam, inning, true)}
+                  {ScoreCalculator.calculateTeamInningScore(
+                    awayTeam,
+                    runEvents,
+                    inning,
+                    true
+                  )}
                 </TableCell>
               ))}
               <TableCell
@@ -397,7 +353,12 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                     ...(inning === currentInning ? highlightStyles : {}),
                   }}
                 >
-                  {calculateScore(homeTeam, inning, false)}
+                  {ScoreCalculator.calculateTeamInningScore(
+                    homeTeam,
+                    runEvents,
+                    inning,
+                    false
+                  )}
                 </TableCell>
               ))}
               <TableCell

--- a/src/components/TeamStatsList.tsx
+++ b/src/components/TeamStatsList.tsx
@@ -180,9 +180,9 @@ const TeamStatsList: React.FC = () => {
                   <TableCell align="center">{stats.draws}</TableCell>
                   <TableCell align="center">
                     {stats.wins + stats.losses > 0
-                      ? (stats.wins / (stats.wins + stats.losses))
-                          .toFixed(3)
-                          .substring(1)
+                      ? formatBattingAvg(
+                          stats.wins / (stats.wins + stats.losses)
+                        )
                       : '.000'}
                   </TableCell>
                   <TableCell align="center">{stats.totalRuns}</TableCell>

--- a/src/components/__tests__/TeamStatsList.test.tsx
+++ b/src/components/__tests__/TeamStatsList.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import TeamStatsList from '../TeamStatsList';
+import { getAllTeamStats, TeamStats } from '../../firebase/statsService';
+
+jest.mock('../../firebase/statsService', () => ({
+  getAllTeamStats: jest.fn(),
+}));
+
+const mockedGetAllTeamStats = getAllTeamStats as jest.MockedFunction<
+  typeof getAllTeamStats
+>;
+
+const allWins: TeamStats = {
+  teamId: 'team-1',
+  teamName: '全勝チーム',
+  gameCount: 2,
+  wins: 2,
+  losses: 0,
+  draws: 0,
+  totalRuns: 8,
+  totalRunsAllowed: 1,
+  battingStats: {
+    atBats: 0,
+    hits: 0,
+    singles: 0,
+    doubles: 0,
+    triples: 0,
+    homeRuns: 0,
+    walks: 0,
+    sacrificeFlies: 0,
+    strikeouts: 0,
+    rbis: 0,
+    battingAvg: 0,
+    obp: 0,
+    slg: 0,
+    ops: 0,
+  },
+  playerStats: [],
+};
+
+describe('TeamStatsList', () => {
+  test('全勝チームの勝率を1.000と表示する', async () => {
+    mockedGetAllTeamStats.mockResolvedValue([allWins]);
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <TeamStatsList />
+      </ThemeProvider>
+    );
+
+    expect(await screen.findByText('全勝チーム')).toBeInTheDocument();
+    expect(screen.getByText('1.000')).toBeInTheDocument();
+  });
+});

--- a/src/firebase/__tests__/statsService.test.ts
+++ b/src/firebase/__tests__/statsService.test.ts
@@ -1,0 +1,81 @@
+import { getDocs } from 'firebase/firestore';
+import { getCurrentUser } from '../authService';
+import { getAllTeamStats } from '../statsService';
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+}));
+
+jest.mock('../config', () => ({ db: {} }));
+jest.mock('../authService', () => ({ getCurrentUser: jest.fn() }));
+
+const mockedGetDocs = getDocs as jest.Mock;
+const mockedGetCurrentUser = getCurrentUser as jest.Mock;
+
+describe('getAllTeamStats', () => {
+  test('正式な式でチームと選手の出塁率を集計する', async () => {
+    mockedGetCurrentUser.mockReturnValue({ uid: 'user-1' });
+    mockedGetDocs.mockResolvedValue({
+      docs: [
+        {
+          id: 'game-1',
+          data: () => ({
+            date: '2026-08-22',
+            currentInning: 1,
+            runEvents: [],
+            homeTeam: {
+              id: 'home',
+              name: 'ホーム',
+              players: [
+                {
+                  id: 'player-1',
+                  name: '打者',
+                  number: '1',
+                  position: '投手',
+                  isActive: true,
+                  order: 1,
+                },
+              ],
+              atBats: [
+                {
+                  id: 'ab-1',
+                  playerId: 'player-1',
+                  result: 'HR',
+                  inning: 1,
+                  rbi: 1,
+                  isOut: false,
+                  isTop: false,
+                },
+                {
+                  id: 'ab-2',
+                  playerId: 'player-1',
+                  result: 'SAC',
+                  inning: 1,
+                  rbi: 0,
+                  isOut: true,
+                  isTop: false,
+                },
+              ],
+            },
+            awayTeam: {
+              id: 'away',
+              name: 'アウェイ',
+              players: [],
+              atBats: [],
+            },
+          }),
+        },
+      ],
+    });
+
+    const stats = await getAllTeamStats();
+    const homeStats = stats.find((team) => team.teamId === 'home');
+
+    expect(homeStats?.battingStats.obp).toBe(1);
+    expect(homeStats?.playerStats[0].obp).toBe(1);
+  });
+});

--- a/src/firebase/statsService.ts
+++ b/src/firebase/statsService.ts
@@ -1,7 +1,8 @@
 import { collection, getDocs, query, where, orderBy } from 'firebase/firestore';
 import { db } from './config';
-import { Game, Team, AtBat, RunEvent, Player } from '../types';
+import { Game, Team, AtBat, Player } from '../types';
 import { getCurrentUser } from './authService';
+import { BattingStats, ScoreCalculator } from '../services/ScoreCalculator';
 
 // チームの通算成績インターフェース
 export interface TeamStats {
@@ -13,44 +14,17 @@ export interface TeamStats {
   draws: number;
   totalRuns: number;
   totalRunsAllowed: number;
-  battingStats: {
-    atBats: number;
-    hits: number;
-    singles: number;
-    doubles: number;
-    triples: number;
-    homeRuns: number;
-    walks: number;
-    strikeouts: number;
-    rbis: number;
-    battingAvg: number;
-    obp: number;
-    slg: number;
-    ops: number;
-  };
+  battingStats: BattingStats;
   playerStats: PlayerBattingStats[]; // 選手ごとの打撃成績を追加
 }
 
 // 選手の打撃成績インターフェース
-export interface PlayerBattingStats {
+export interface PlayerBattingStats extends BattingStats {
   playerId: string;
   playerName: string;
   playerNumber: string;
   playerPosition: string;
   gameCount: number;
-  atBats: number;
-  hits: number;
-  singles: number;
-  doubles: number;
-  triples: number;
-  homeRuns: number;
-  walks: number;
-  strikeouts: number;
-  rbis: number;
-  battingAvg: number;
-  obp: number;
-  slg: number;
-  ops: number;
 }
 
 // ゲームコレクションの定数
@@ -129,12 +103,12 @@ const processTeamStats = (
   teamStats.gameCount++;
 
   // 得点計算
-  const homeScore = calculateTotalScore(
+  const homeScore = ScoreCalculator.calculateTotalScore(
     game.homeTeam,
     game.runEvents || [],
     false
   );
-  const awayScore = calculateTotalScore(
+  const awayScore = ScoreCalculator.calculateTotalScore(
     game.awayTeam,
     game.runEvents || [],
     true
@@ -170,7 +144,7 @@ const processTeamStats = (
   }
 
   // 打撃成績の集計
-  aggregateBattingStats(teamStats, team.atBats);
+  aggregateBattingStats(teamStats.battingStats, team.atBats);
 
   // 選手ごとの打撃成績を集計
   aggregatePlayerBattingStats(teamStats, team);
@@ -195,6 +169,7 @@ const createEmptyTeamStats = (teamId: string, teamName: string): TeamStats => {
       triples: 0,
       homeRuns: 0,
       walks: 0,
+      sacrificeFlies: 0,
       strikeouts: 0,
       rbis: 0,
       battingAvg: 0,
@@ -207,66 +182,25 @@ const createEmptyTeamStats = (teamId: string, teamName: string): TeamStats => {
 };
 
 // 打撃成績を集計
-const aggregateBattingStats = (teamStats: TeamStats, atBats: AtBat[]) => {
-  const stats = teamStats.battingStats;
+const BATTING_COUNT_KEYS = [
+  'atBats',
+  'hits',
+  'singles',
+  'doubles',
+  'triples',
+  'homeRuns',
+  'walks',
+  'sacrificeFlies',
+  'strikeouts',
+  'rbis',
+] as const;
 
-  // 打点の合計
-  stats.rbis += atBats.reduce((sum, atBat) => sum + (atBat.rbi || 0), 0);
-
-  // 打撃結果の集計
-  atBats.forEach((atBat) => {
-    const result = atBat.result;
-
-    // 四球/死球はカウント
-    if (result === 'BB' || result === 'HBP') {
-      stats.walks++;
-      return;
-    }
-
-    // 犠打/犠飛はカウントしない
-    if (result === 'SAC' || result === 'SF') {
-      return;
-    }
-
-    // 三振のカウント
-    if (result === 'SO') {
-      stats.strikeouts++;
-    }
-
-    // 打数にカウントするケース
-    stats.atBats++;
-
-    // 安打の種類に応じてカウント
-    if (['IH', 'LH', 'CH', 'RH'].includes(result)) {
-      stats.hits++;
-      stats.singles++;
-    } else if (result === '2B') {
-      stats.hits++;
-      stats.doubles++;
-    } else if (result === '3B') {
-      stats.hits++;
-      stats.triples++;
-    } else if (result === 'HR') {
-      stats.hits++;
-      stats.homeRuns++;
-    }
-  });
-
-  // 打率計算 (打数が0の場合は0)
-  stats.battingAvg = stats.atBats > 0 ? stats.hits / stats.atBats : 0;
-
-  // 出塁率計算 (打数+四球が0の場合は0)
-  const plateAppearances = stats.atBats + stats.walks;
-  stats.obp =
-    plateAppearances > 0 ? (stats.hits + stats.walks) / plateAppearances : 0;
-
-  // 長打率計算 (打数が0の場合は0)
-  const totalBases =
-    stats.singles + stats.doubles * 2 + stats.triples * 3 + stats.homeRuns * 4;
-  stats.slg = stats.atBats > 0 ? totalBases / stats.atBats : 0;
-
-  // OPS計算
-  stats.ops = stats.obp + stats.slg;
+const aggregateBattingStats = (stats: BattingStats, atBats: AtBat[]) => {
+  const addedStats = ScoreCalculator.calculateBattingStats(atBats);
+  for (const key of BATTING_COUNT_KEYS) {
+    stats[key] += addedStats[key];
+  }
+  Object.assign(stats, ScoreCalculator.calculateBattingRates(stats));
 };
 
 // 選手ごとの打撃成績を集計
@@ -292,73 +226,7 @@ const aggregatePlayerBattingStats = (teamStats: TeamStats, team: Team) => {
       (atBat) => atBat.playerId === player.id
     );
 
-    // 打点の合計
-    playerStats.rbis += playerAtBats.reduce(
-      (sum, atBat) => sum + (atBat.rbi || 0),
-      0
-    );
-
-    // 打撃結果の集計
-    playerAtBats.forEach((atBat) => {
-      const result = atBat.result;
-
-      // 四球/死球はカウント
-      if (result === 'BB' || result === 'HBP') {
-        playerStats!.walks++;
-        return;
-      }
-
-      // 犠打/犠飛はカウントしない
-      if (result === 'SAC' || result === 'SF') {
-        return;
-      }
-
-      // 三振のカウント
-      if (result === 'SO') {
-        playerStats!.strikeouts++;
-      }
-
-      // 打数にカウントするケース
-      playerStats!.atBats++;
-
-      // 安打の種類に応じてカウント
-      if (['IH', 'LH', 'CH', 'RH'].includes(result)) {
-        playerStats!.hits++;
-        playerStats!.singles++;
-      } else if (result === '2B') {
-        playerStats!.hits++;
-        playerStats!.doubles++;
-      } else if (result === '3B') {
-        playerStats!.hits++;
-        playerStats!.triples++;
-      } else if (result === 'HR') {
-        playerStats!.hits++;
-        playerStats!.homeRuns++;
-      }
-    });
-
-    // 打率計算 (打数が0の場合は0)
-    playerStats.battingAvg =
-      playerStats.atBats > 0 ? playerStats.hits / playerStats.atBats : 0;
-
-    // 出塁率計算 (打数+四球が0の場合は0)
-    const plateAppearances = playerStats.atBats + playerStats.walks;
-    playerStats.obp =
-      plateAppearances > 0
-        ? (playerStats.hits + playerStats.walks) / plateAppearances
-        : 0;
-
-    // 長打率計算 (打数が0の場合は0)
-    const totalBases =
-      playerStats.singles +
-      playerStats.doubles * 2 +
-      playerStats.triples * 3 +
-      playerStats.homeRuns * 4;
-    playerStats.slg =
-      playerStats.atBats > 0 ? totalBases / playerStats.atBats : 0;
-
-    // OPS計算
-    playerStats.ops = playerStats.obp + playerStats.slg;
+    aggregateBattingStats(playerStats, playerAtBats);
   });
 
   // プレイヤー成績を打率の降順でソート
@@ -393,6 +261,7 @@ const createEmptyPlayerStats = (player: Player): PlayerBattingStats => {
     triples: 0,
     homeRuns: 0,
     walks: 0,
+    sacrificeFlies: 0,
     strikeouts: 0,
     rbis: 0,
     battingAvg: 0,
@@ -400,24 +269,4 @@ const createEmptyPlayerStats = (player: Player): PlayerBattingStats => {
     slg: 0,
     ops: 0,
   };
-};
-
-// チームの合計得点を計算
-const calculateTotalScore = (
-  team: Team,
-  runEvents: RunEvent[],
-  isAwayTeam: boolean
-): number => {
-  // 全ての打席結果の打点を合計
-  const atBatTotal = team.atBats.reduce(
-    (total, atBat) => total + (atBat.rbi || 0),
-    0
-  );
-
-  // 全ての得点イベントを合計
-  const runEventTotal = runEvents
-    .filter((event) => event.isTop === isAwayTeam)
-    .reduce((total, event) => total + (event.runCount || 0), 0);
-
-  return atBatTotal + runEventTotal;
 };

--- a/src/hooks/useScoreCalculation.ts
+++ b/src/hooks/useScoreCalculation.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Team, RunEvent } from '../types';
+import { ScoreCalculator } from '../services/ScoreCalculator';
 
 export interface ScoreData {
   totalScore: number;
@@ -20,20 +21,6 @@ export interface UseScoreCalculationReturn {
  * - RunEvent は runCount を用いる
  * - 先攻(away)は表(isTop: true)、後攻(home)は裏(isTop: false)
  */
-const HIT_RESULTS = ['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR'];
-
-const calculateTotalScore = (
-  team: Team,
-  isAwayTeam: boolean,
-  runEvents: RunEvent[]
-): number => {
-  const atBatTotal = team.atBats.reduce((sum, ab) => sum + (ab.rbi || 0), 0);
-  const runEventTotal = runEvents
-    .filter((e) => e.isTop === isAwayTeam)
-    .reduce((sum, e) => sum + (e.runCount || 0), 0);
-  return atBatTotal + runEventTotal;
-};
-
 const calculateInningScores = (
   team: Team,
   isAwayTeam: boolean,
@@ -42,22 +29,18 @@ const calculateInningScores = (
 ): number[] => {
   const scores: number[] = [];
   for (let i = 1; i <= maxInning; i++) {
-    const atBatInning = team.atBats
-      .filter((ab) => ab.inning === i)
-      .reduce((sum, ab) => sum + (ab.rbi || 0), 0);
-    const runEventInning = runEvents
-      .filter((e) => e.inning === i && e.isTop === isAwayTeam)
-      .reduce((sum, e) => sum + (e.runCount || 0), 0);
-    scores.push(atBatInning + runEventInning);
+    scores.push(
+      ScoreCalculator.calculateTeamInningScore(team, runEvents, i, isAwayTeam)
+    );
   }
   return scores;
 };
 
 const calculateHits = (team: Team): number =>
-  team.atBats.filter((ab) => HIT_RESULTS.includes(ab.result)).length;
+  ScoreCalculator.calculateHits(team.atBats);
 
 const calculateErrors = (team: Team): number =>
-  team.atBats.filter((ab) => ab.result === 'E').length;
+  ScoreCalculator.calculateErrors(team.atBats);
 
 const determineMaxInning = (runEvents: RunEvent[]): number => {
   if (runEvents.length === 0) {
@@ -75,7 +58,11 @@ export const useScoreCalculation = (
 
   const homeScore = useMemo<ScoreData>(
     () => ({
-      totalScore: calculateTotalScore(homeTeam, false, runEvents),
+      totalScore: ScoreCalculator.calculateTotalScore(
+        homeTeam,
+        runEvents,
+        false
+      ),
       inningScores: calculateInningScores(
         homeTeam,
         false,
@@ -90,7 +77,11 @@ export const useScoreCalculation = (
 
   const awayScore = useMemo<ScoreData>(
     () => ({
-      totalScore: calculateTotalScore(awayTeam, true, runEvents),
+      totalScore: ScoreCalculator.calculateTotalScore(
+        awayTeam,
+        runEvents,
+        true
+      ),
       inningScores: calculateInningScores(awayTeam, true, runEvents, maxInning),
       hits: calculateHits(awayTeam),
       errors: calculateErrors(awayTeam),
@@ -100,13 +91,12 @@ export const useScoreCalculation = (
 
   const calculateInningScore = (team: Team, inning: number): number => {
     const isAwayTeam = team === awayTeam;
-    const atBatInning = team.atBats
-      .filter((ab) => ab.inning === inning)
-      .reduce((sum, ab) => sum + (ab.rbi || 0), 0);
-    const runEventInning = runEvents
-      .filter((e) => e.inning === inning && e.isTop === isAwayTeam)
-      .reduce((sum, e) => sum + (e.runCount || 0), 0);
-    return atBatInning + runEventInning;
+    return ScoreCalculator.calculateTeamInningScore(
+      team,
+      runEvents,
+      inning,
+      isAwayTeam
+    );
   };
 
   return { homeScore, awayScore, calculateInningScore };

--- a/src/services/ScoreCalculator.ts
+++ b/src/services/ScoreCalculator.ts
@@ -21,7 +21,7 @@ export interface BattingStats {
   doubles: number;
   triples: number;
   homeRuns: number;
-  walks: number;
+  walks: number; // 四球と死球の合計
   sacrificeFlies: number;
   strikeouts: number;
   rbis: number;
@@ -66,6 +66,7 @@ export class ScoreCalculator {
       .reduce((sum, event) => sum + (event.runCount || 0), 0);
   }
 
+  /** 先攻は表、後攻は裏としてチームのイニング得点を計算する。 */
   static calculateTeamInningScore(
     team: Team,
     runEvents: RunEvent[],
@@ -168,22 +169,6 @@ export class ScoreCalculator {
     }
 
     return { ...stats, ...this.calculateBattingRates(stats) };
-  }
-
-  static calculateBattingAverage(atBats: AtBat[]): number {
-    return this.calculateBattingStats(atBats).battingAvg;
-  }
-
-  static calculateSluggingPercentage(atBats: AtBat[]): number {
-    return this.calculateBattingStats(atBats).slg;
-  }
-
-  static calculateOnBasePercentage(atBats: AtBat[]): number {
-    return this.calculateBattingStats(atBats).obp;
-  }
-
-  static calculateOPS(atBats: AtBat[]): number {
-    return this.calculateBattingStats(atBats).ops;
   }
 
   static determineWinner(

--- a/src/services/ScoreCalculator.ts
+++ b/src/services/ScoreCalculator.ts
@@ -1,7 +1,50 @@
-import { RunEvent, AtBat } from '../types';
+import { RunEvent, AtBat, HitResult, Team } from '../types';
+
+export const SINGLE_RESULTS: readonly HitResult[] = ['IH', 'LH', 'CH', 'RH'];
+export const HIT_RESULTS: readonly HitResult[] = [
+  ...SINGLE_RESULTS,
+  '2B',
+  '3B',
+  'HR',
+];
+export const NON_AT_BAT_RESULTS: readonly HitResult[] = [
+  'BB',
+  'HBP',
+  'SAC',
+  'SF',
+];
+
+export interface BattingStats {
+  atBats: number;
+  hits: number;
+  singles: number;
+  doubles: number;
+  triples: number;
+  homeRuns: number;
+  walks: number;
+  sacrificeFlies: number;
+  strikeouts: number;
+  rbis: number;
+  battingAvg: number;
+  obp: number;
+  slg: number;
+  ops: number;
+}
+
+type BattingRateCounts = Pick<
+  BattingStats,
+  | 'atBats'
+  | 'hits'
+  | 'singles'
+  | 'doubles'
+  | 'triples'
+  | 'homeRuns'
+  | 'walks'
+  | 'sacrificeFlies'
+>;
 
 /**
- * スコア計算を行う純粋関数群
+ * スコアと打撃成績を計算する純粋関数群
  */
 export class ScoreCalculator {
   static calculateInningScore(
@@ -10,8 +53,8 @@ export class ScoreCalculator {
     isTop: boolean
   ): number {
     return runEvents
-      .filter((e) => e.inning === inning && e.isTop === isTop)
-      .reduce((sum, e) => sum + (e.runCount || 0), 0);
+      .filter((event) => event.inning === inning && event.isTop === isTop)
+      .reduce((sum, event) => sum + (event.runCount || 0), 0);
   }
 
   static calculateTotalRunEvents(
@@ -19,63 +62,128 @@ export class ScoreCalculator {
     isTop: boolean
   ): number {
     return runEvents
-      .filter((e) => e.isTop === isTop)
-      .reduce((sum, e) => sum + (e.runCount || 0), 0);
+      .filter((event) => event.isTop === isTop)
+      .reduce((sum, event) => sum + (event.runCount || 0), 0);
+  }
+
+  static calculateTeamInningScore(
+    team: Team,
+    runEvents: RunEvent[],
+    inning: number,
+    isAwayTeam: boolean
+  ): number {
+    const atBatRuns = team.atBats
+      .filter((atBat) => atBat.inning === inning)
+      .reduce((sum, atBat) => sum + (atBat.rbi || 0), 0);
+    return atBatRuns + this.calculateInningScore(runEvents, inning, isAwayTeam);
+  }
+
+  static calculateTotalScore(
+    team: Team,
+    runEvents: RunEvent[],
+    isAwayTeam: boolean
+  ): number {
+    const atBatRuns = team.atBats.reduce(
+      (sum, atBat) => sum + (atBat.rbi || 0),
+      0
+    );
+    return atBatRuns + this.calculateTotalRunEvents(runEvents, isAwayTeam);
   }
 
   static calculateHits(atBats: AtBat[]): number {
-    const hitResults = ['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR'];
-    return atBats.filter((ab) => hitResults.includes(ab.result)).length;
+    return atBats.filter((atBat) => HIT_RESULTS.includes(atBat.result)).length;
+  }
+
+  static calculateErrors(atBats: AtBat[]): number {
+    return atBats.filter((atBat) => atBat.result === 'E').length;
+  }
+
+  static calculateBattingRates(
+    counts: BattingRateCounts
+  ): Pick<BattingStats, 'battingAvg' | 'obp' | 'slg' | 'ops'> {
+    const battingAvg = counts.atBats > 0 ? counts.hits / counts.atBats : 0;
+    const onBaseDenominator =
+      counts.atBats + counts.walks + counts.sacrificeFlies;
+    const obp =
+      onBaseDenominator > 0
+        ? (counts.hits + counts.walks) / onBaseDenominator
+        : 0;
+    const totalBases =
+      counts.singles +
+      counts.doubles * 2 +
+      counts.triples * 3 +
+      counts.homeRuns * 4;
+    const slg = counts.atBats > 0 ? totalBases / counts.atBats : 0;
+
+    return { battingAvg, obp, slg, ops: obp + slg };
+  }
+
+  static calculateBattingStats(atBats: AtBat[]): BattingStats {
+    const stats: BattingStats = {
+      atBats: 0,
+      hits: 0,
+      singles: 0,
+      doubles: 0,
+      triples: 0,
+      homeRuns: 0,
+      walks: 0,
+      sacrificeFlies: 0,
+      strikeouts: 0,
+      rbis: 0,
+      battingAvg: 0,
+      obp: 0,
+      slg: 0,
+      ops: 0,
+    };
+
+    for (const atBat of atBats) {
+      stats.rbis += atBat.rbi || 0;
+
+      if (NON_AT_BAT_RESULTS.includes(atBat.result)) {
+        if (atBat.result === 'BB' || atBat.result === 'HBP') {
+          stats.walks++;
+        } else if (atBat.result === 'SF') {
+          stats.sacrificeFlies++;
+        }
+        continue;
+      }
+
+      stats.atBats++;
+      if (atBat.result === 'SO') {
+        stats.strikeouts++;
+      }
+      if (SINGLE_RESULTS.includes(atBat.result)) {
+        stats.hits++;
+        stats.singles++;
+      } else if (atBat.result === '2B') {
+        stats.hits++;
+        stats.doubles++;
+      } else if (atBat.result === '3B') {
+        stats.hits++;
+        stats.triples++;
+      } else if (atBat.result === 'HR') {
+        stats.hits++;
+        stats.homeRuns++;
+      }
+    }
+
+    return { ...stats, ...this.calculateBattingRates(stats) };
   }
 
   static calculateBattingAverage(atBats: AtBat[]): number {
-    const validAtBats = atBats.filter(
-      (ab) => !['BB', 'HBP', 'SAC', 'SF'].includes(ab.result)
-    );
-    if (validAtBats.length === 0) return 0;
-    const hits = this.calculateHits(validAtBats);
-    return hits / validAtBats.length;
+    return this.calculateBattingStats(atBats).battingAvg;
   }
 
   static calculateSluggingPercentage(atBats: AtBat[]): number {
-    const validAtBats = atBats.filter(
-      (ab) => !['BB', 'HBP', 'SAC', 'SF'].includes(ab.result)
-    );
-    if (validAtBats.length === 0) return 0;
-    const totalBases = validAtBats.reduce((sum, ab) => {
-      switch (ab.result) {
-        case 'IH':
-        case 'LH':
-        case 'CH':
-        case 'RH':
-          return sum + 1;
-        case '2B':
-          return sum + 2;
-        case '3B':
-          return sum + 3;
-        case 'HR':
-          return sum + 4;
-        default:
-          return sum;
-      }
-    }, 0);
-    return totalBases / validAtBats.length;
+    return this.calculateBattingStats(atBats).slg;
   }
 
   static calculateOnBasePercentage(atBats: AtBat[]): number {
-    if (atBats.length === 0) return 0;
-    const timesOnBase = atBats.filter((ab) =>
-      ['IH', 'LH', 'CH', 'RH', '2B', '3B', 'HR', 'BB', 'HBP'].includes(
-        ab.result
-      )
-    ).length;
-    return timesOnBase / atBats.length;
+    return this.calculateBattingStats(atBats).obp;
   }
 
   static calculateOPS(atBats: AtBat[]): number {
-    const obp = this.calculateOnBasePercentage(atBats);
-    const slg = this.calculateSluggingPercentage(atBats);
-    return obp + slg;
+    return this.calculateBattingStats(atBats).ops;
   }
 
   static determineWinner(

--- a/src/services/__tests__/ScoreCalculator.test.ts
+++ b/src/services/__tests__/ScoreCalculator.test.ts
@@ -42,7 +42,7 @@ describe('ScoreCalculator', () => {
     });
   });
 
-  describe('calculateBattingAverage', () => {
+  describe('calculateBattingStats', () => {
     test('打率を正しく計算する', () => {
       const atBats: AtBat[] = [
         {
@@ -82,7 +82,9 @@ describe('ScoreCalculator', () => {
           isTop: true,
         },
       ];
-      expect(ScoreCalculator.calculateBattingAverage(atBats)).toBe(0.5);
+      expect(ScoreCalculator.calculateBattingStats(atBats).battingAvg).toBe(
+        0.5
+      );
     });
 
     test('四球は打数に含めない', () => {
@@ -115,11 +117,13 @@ describe('ScoreCalculator', () => {
           isTop: true,
         },
       ];
-      expect(ScoreCalculator.calculateBattingAverage(atBats)).toBe(0.5);
+      expect(ScoreCalculator.calculateBattingStats(atBats).battingAvg).toBe(
+        0.5
+      );
     });
   });
 
-  describe('calculateOPS', () => {
+  describe('OPS', () => {
     test('OPSを正しく計算する', () => {
       const atBats: AtBat[] = [
         {
@@ -159,12 +163,12 @@ describe('ScoreCalculator', () => {
           isTop: true,
         },
       ];
-      const ops = ScoreCalculator.calculateOPS(atBats);
+      const { ops } = ScoreCalculator.calculateBattingStats(atBats);
       expect(ops).toBeGreaterThan(0);
     });
   });
 
-  describe('calculateOnBasePercentage', () => {
+  describe('出塁率', () => {
     test('犠打を出塁率の分母に含めない', () => {
       const atBats: AtBat[] = [
         {
@@ -187,7 +191,7 @@ describe('ScoreCalculator', () => {
         },
       ];
 
-      expect(ScoreCalculator.calculateOnBasePercentage(atBats)).toBe(1);
+      expect(ScoreCalculator.calculateBattingStats(atBats).obp).toBe(1);
     });
 
     test('犠飛を出塁率の分母に含める', () => {
@@ -212,7 +216,7 @@ describe('ScoreCalculator', () => {
         },
       ];
 
-      expect(ScoreCalculator.calculateOnBasePercentage(atBats)).toBe(0.5);
+      expect(ScoreCalculator.calculateBattingStats(atBats).obp).toBe(0.5);
     });
   });
 

--- a/src/services/__tests__/ScoreCalculator.test.ts
+++ b/src/services/__tests__/ScoreCalculator.test.ts
@@ -164,6 +164,58 @@ describe('ScoreCalculator', () => {
     });
   });
 
+  describe('calculateOnBasePercentage', () => {
+    test('犠打を出塁率の分母に含めない', () => {
+      const atBats: AtBat[] = [
+        {
+          id: 'a1',
+          playerId: 'p1',
+          result: 'HR',
+          inning: 1,
+          rbi: 1,
+          isOut: false,
+          isTop: true,
+        },
+        {
+          id: 'a2',
+          playerId: 'p1',
+          result: 'SAC',
+          inning: 1,
+          rbi: 0,
+          isOut: true,
+          isTop: true,
+        },
+      ];
+
+      expect(ScoreCalculator.calculateOnBasePercentage(atBats)).toBe(1);
+    });
+
+    test('犠飛を出塁率の分母に含める', () => {
+      const atBats: AtBat[] = [
+        {
+          id: 'a1',
+          playerId: 'p1',
+          result: 'IH',
+          inning: 1,
+          rbi: 0,
+          isOut: false,
+          isTop: true,
+        },
+        {
+          id: 'a2',
+          playerId: 'p1',
+          result: 'SF',
+          inning: 1,
+          rbi: 1,
+          isOut: true,
+          isTop: true,
+        },
+      ];
+
+      expect(ScoreCalculator.calculateOnBasePercentage(atBats)).toBe(0.5);
+    });
+  });
+
   describe('determineWinner', () => {
     test('ホームの勝利を正しく判定する', () => {
       expect(ScoreCalculator.determineWinner(5, 3)).toBe('home');


### PR DESCRIPTION
## Summary
- correct OBP to use `(H + BB + HBP) / (AB + BB + HBP + SF)`
- preserve `1.000` when formatting undefeated-team winning percentage
- centralize batting, score, hit, and error calculations in `ScoreCalculator`
- reuse shared hit and non-at-bat result constants across production consumers

## Verification
- `npm run ci:local`
- `MAX_BUNDLE_SIZE_MB=1.25 node scripts/check-bundle-size.js`
- `COVERAGE_THRESHOLD=30 node scripts/check-coverage.js`
- `npm audit --audit-level=high`

## Firebase / security impact
- no Firestore schema or security-rule changes
- no Firebase deployment in this PR; deployment follows the complete serial issue set

Closes #197