### PR TITLE
fix: guard at-bat editing invariants

### DIFF
--- a/src/components/AtBatForm.tsx
+++ b/src/components/AtBatForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   Box,
   Button,
@@ -22,6 +22,8 @@ import {
 import { HitResult, Player, AtBat } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import { HIT_RESULTS, OUT_RESULTS } from '../services/ScoreCalculator';
+
+const DEFAULT_RESULT: HitResult = 'GO_2B';
 
 // カスタムカラー定義
 const customColors = {
@@ -160,7 +162,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   onUpdateAtBat,
   onCancelEdit,
 }) => {
-  const [result, setResult] = useState<HitResult>('GO_2B');
+  const [result, setResult] = useState<HitResult>(DEFAULT_RESULT);
   const [description, setDescription] = useState('');
   const [rbi, setRbi] = useState<number>(0);
   const [successMessage, setSuccessMessage] = useState('');
@@ -168,19 +170,23 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   // フォーカス管理用のref
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
+  const resetFormFields = useCallback(() => {
+    setResult(DEFAULT_RESULT);
+    setDescription('');
+    setRbi(0);
+  }, []);
+
   // 編集モードの場合、フォームに値をセット
   useEffect(() => {
     if (editingAtBat) {
       setResult(editingAtBat.result);
       setDescription(editingAtBat.description || '');
       setRbi(editingAtBat.rbi || 0);
-    } else {
-      setResult('GO_2B');
-      setDescription('');
-      setRbi(0);
       setSuccessMessage('');
+    } else {
+      resetFormFields();
     }
-  }, [editingAtBat]);
+  }, [editingAtBat, resetFormFields]);
 
   // 成功メッセージを3秒後に自動的にクリア
   useEffect(() => {
@@ -239,14 +245,10 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
 
       onAddAtBat(newAtBat);
       setSuccessMessage('打席結果を登録しました');
-    } else {
-      return;
     }
 
     // フォームをリセット
-    setResult('GO_2B');
-    setDescription('');
-    setRbi(0);
+    resetFormFields();
 
     // 送信ボタンにフォーカスを戻す
     if (submitButtonRef.current) {
@@ -261,9 +263,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
     }
 
     // フォームをリセット
-    setResult('GO_2B');
-    setDescription('');
-    setRbi(0);
+    resetFormFields();
     setSuccessMessage('');
   };
 
@@ -395,6 +395,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
                   variant="contained"
                   color="primary"
                   fullWidth
+                  disabled={!onUpdateAtBat}
                 >
                   更新
                 </Button>

--- a/src/components/AtBatForm.tsx
+++ b/src/components/AtBatForm.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/icons-material';
 import { HitResult, Player, AtBat } from '../types';
 import { v4 as uuidv4 } from 'uuid';
-import { HIT_RESULTS } from '../services/ScoreCalculator';
+import { HIT_RESULTS, OUT_RESULTS } from '../services/ScoreCalculator';
 
 // カスタムカラー定義
 const customColors = {
@@ -33,30 +33,12 @@ const customColors = {
 
 // 結果に応じた色を返す関数
 const getResultColor = (result: HitResult): string => {
-  const outPatterns = [
-    'GO_P',
-    'GO_C',
-    'GO_1B',
-    'GO_2B',
-    'GO_3B',
-    'GO_SS',
-    'GO_RF',
-    'FO_LF',
-    'FO_CF',
-    'FO_RF',
-    'FO_IF',
-    'LO',
-    'DP',
-    'SO',
-    'SAC',
-    'SF',
-  ];
   const walkPatterns = ['BB', 'HBP'];
 
   if (HIT_RESULTS.includes(result)) {
     return customColors.hit;
   }
-  if (outPatterns.includes(result)) {
+  if (OUT_RESULTS.includes(result)) {
     return customColors.out;
   }
   if (walkPatterns.includes(result)) {
@@ -114,24 +96,7 @@ const hitResultLabels: Record<HitResult, string> = {
 
 // 結果がアウトかどうかを判定する関数
 const isOutResult = (result: HitResult): boolean => {
-  return [
-    'GO_P',
-    'GO_C',
-    'GO_1B',
-    'GO_2B',
-    'GO_3B',
-    'GO_SS',
-    'GO_RF',
-    'FO_LF',
-    'FO_CF',
-    'FO_RF',
-    'FO_IF',
-    'LO',
-    'DP',
-    'SAC',
-    'SF',
-    'SO',
-  ].includes(result);
+  return OUT_RESULTS.includes(result);
 };
 
 // 打撃結果をカテゴリごとにグループ化（定数なのでコンポーネント外に配置）
@@ -176,7 +141,7 @@ const getCategoryIcon = (category: string) => {
     case 'その他アウト':
       return <CancelIcon fontSize="small" sx={{ color: customColors.out }} />;
     case '犠打/犠飛':
-      return <SportsIcon fontSize="small" sx={{ color: customColors.other }} />;
+      return <SportsIcon fontSize="small" sx={{ color: customColors.out }} />;
     case 'その他':
       return (
         <MoreHorizIcon fontSize="small" sx={{ color: customColors.walk }} />
@@ -201,7 +166,6 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   const [successMessage, setSuccessMessage] = useState('');
 
   // フォーカス管理用のref
-  const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
   // 編集モードの場合、フォームに値をセット
@@ -210,6 +174,11 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
       setResult(editingAtBat.result);
       setDescription(editingAtBat.description || '');
       setRbi(editingAtBat.rbi || 0);
+    } else {
+      setResult('GO_2B');
+      setDescription('');
+      setRbi(0);
+      setSuccessMessage('');
     }
   }, [editingAtBat]);
 
@@ -240,7 +209,9 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (isEditMode && editingAtBat && onUpdateAtBat) {
+    if (isEditMode && editingAtBat) {
+      if (!onUpdateAtBat) return;
+
       // 編集モードの場合
       const updatedAtBat: AtBat = {
         ...editingAtBat,
@@ -252,11 +223,11 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
 
       onUpdateAtBat(updatedAtBat);
       setSuccessMessage('打席結果を更新しました');
-    } else {
+    } else if (player) {
       // 新規登録モードの場合
       const newAtBat: AtBat = {
         id: uuidv4(),
-        playerId: player!.id,
+        playerId: player.id,
         inning,
         isTop,
         result,
@@ -268,6 +239,8 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
 
       onAddAtBat(newAtBat);
       setSuccessMessage('打席結果を登録しました');
+    } else {
+      return;
     }
 
     // フォームをリセット
@@ -426,7 +399,6 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
                   更新
                 </Button>
                 <Button
-                  ref={cancelButtonRef}
                   variant="outlined"
                   color="secondary"
                   fullWidth

--- a/src/components/__tests__/AtBatForm.test.tsx
+++ b/src/components/__tests__/AtBatForm.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import AtBatForm from '../AtBatForm';
+import { AtBat, Player } from '../../types';
+
+jest.mock('uuid', () => ({ v4: () => 'new-at-bat' }));
+
+const player: Player = {
+  id: 'player-1',
+  name: '山田',
+  number: '1',
+  position: '投手',
+  isActive: true,
+  order: 1,
+};
+
+const editingAtBat: AtBat = {
+  id: 'at-bat-1',
+  playerId: player.id,
+  inning: 1,
+  isTop: true,
+  result: 'HR',
+  description: '前回のメモ',
+  rbi: 3,
+  isOut: false,
+};
+
+const renderForm = (props: React.ComponentProps<typeof AtBatForm>) =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <AtBatForm {...props} />
+    </ThemeProvider>
+  );
+
+describe('AtBatForm', () => {
+  test('更新コールバックがなくても新規打席を追加しない', async () => {
+    const onAddAtBat = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({
+      player: null,
+      inning: 1,
+      isTop: true,
+      onAddAtBat,
+      editingAtBat,
+    });
+
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    expect(onAddAtBat).not.toHaveBeenCalled();
+  });
+
+  test('編集対象が外部でクリアされたら入力値を初期化する', async () => {
+    const onAddAtBat = jest.fn();
+    const user = userEvent.setup();
+    const { rerender } = renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat,
+      editingAtBat,
+      onUpdateAtBat: jest.fn(),
+    });
+
+    rerender(
+      <ThemeProvider theme={createTheme()}>
+        <AtBatForm
+          player={player}
+          inning={1}
+          isTop={true}
+          onAddAtBat={onAddAtBat}
+          editingAtBat={null}
+        />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    expect(onAddAtBat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: 'GO_2B',
+        description: undefined,
+        rbi: 0,
+      })
+    );
+  });
+});

--- a/src/components/__tests__/AtBatForm.test.tsx
+++ b/src/components/__tests__/AtBatForm.test.tsx
@@ -37,7 +37,6 @@ const renderForm = (props: React.ComponentProps<typeof AtBatForm>) =>
 describe('AtBatForm', () => {
   test('更新コールバックがなくても新規打席を追加しない', async () => {
     const onAddAtBat = jest.fn();
-    const user = userEvent.setup();
 
     renderForm({
       player: null,
@@ -47,9 +46,39 @@ describe('AtBatForm', () => {
       editingAtBat,
     });
 
-    await user.click(screen.getByRole('button', { name: '更新' }));
+    expect(screen.getByRole('button', { name: '更新' })).toBeDisabled();
 
     expect(onAddAtBat).not.toHaveBeenCalled();
+  });
+
+  test('編集終了後も更新成功メッセージを表示する', async () => {
+    const user = userEvent.setup();
+    const onUpdateAtBat = jest.fn();
+    const { rerender } = renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat: jest.fn(),
+      editingAtBat,
+      onUpdateAtBat,
+    });
+
+    await user.click(screen.getByRole('button', { name: '更新' }));
+    rerender(
+      <ThemeProvider theme={createTheme()}>
+        <AtBatForm
+          player={player}
+          inning={1}
+          isTop={true}
+          onAddAtBat={jest.fn()}
+          editingAtBat={null}
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '打席結果を更新しました'
+    );
   });
 
   test('編集対象が外部でクリアされたら入力値を初期化する', async () => {

--- a/src/hooks/__tests__/useAtBatHistory.test.ts
+++ b/src/hooks/__tests__/useAtBatHistory.test.ts
@@ -144,4 +144,28 @@ describe('useAtBatHistory', () => {
     );
     expect(warn).toHaveBeenCalledTimes(1);
   });
+
+  test('should apply an update after an add in the same batch', () => {
+    const { result } = renderHook(() => useAtBatHistory([]));
+    const newAtBat = { ...initialAtBats[0], id: 'batched' };
+
+    act(() => {
+      result.current.addAtBat(newAtBat);
+      result.current.updateAtBat({ ...newAtBat, result: '2B' });
+    });
+
+    expect(result.current.atBats).toEqual([{ ...newAtBat, result: '2B' }]);
+  });
+
+  test('should apply a delete after an add in the same batch', () => {
+    const { result } = renderHook(() => useAtBatHistory([]));
+    const newAtBat = { ...initialAtBats[0], id: 'batched' };
+
+    act(() => {
+      result.current.addAtBat(newAtBat);
+      result.current.deleteAtBat(newAtBat.id);
+    });
+
+    expect(result.current.atBats).toEqual([]);
+  });
 });

--- a/src/hooks/__tests__/useAtBatHistory.test.ts
+++ b/src/hooks/__tests__/useAtBatHistory.test.ts
@@ -24,6 +24,10 @@ const initialAtBats: AtBat[] = [
 ];
 
 describe('useAtBatHistory', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('should add an at-bat', () => {
     const { result } = renderHook(() => useAtBatHistory(initialAtBats));
     const newAtBat: AtBat = {
@@ -66,13 +70,67 @@ describe('useAtBatHistory', () => {
     expect(result.current.atBats.find((ab) => ab.id === 'ab1')).toBeUndefined();
   });
 
-  test('should set at-bats directly', () => {
+  test('should reset at-bats loaded asynchronously', () => {
     const { result } = renderHook(() => useAtBatHistory([]));
 
     act(() => {
-      result.current.setAtBats(initialAtBats);
+      result.current.resetAtBats(initialAtBats);
     });
 
     expect(result.current.atBats).toHaveLength(2);
+  });
+
+  test('should reject a duplicate id when adding an at-bat', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useAtBatHistory(initialAtBats));
+
+    act(() => {
+      result.current.addAtBat({ ...initialAtBats[0], result: 'HR' });
+    });
+
+    expect(result.current.atBats).toEqual(initialAtBats);
+    expect(warn).toHaveBeenCalledWith('Duplicate at-bat id ignored: ab1');
+  });
+
+  test('should remove duplicate ids when resetting at-bats', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useAtBatHistory([]));
+
+    act(() => {
+      result.current.resetAtBats([
+        initialAtBats[0],
+        { ...initialAtBats[0], result: 'HR' },
+      ]);
+    });
+
+    expect(result.current.atBats).toEqual([initialAtBats[0]]);
+  });
+
+  test('should warn and preserve history when updating a missing id', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useAtBatHistory(initialAtBats));
+
+    act(() => {
+      result.current.updateAtBat({ ...initialAtBats[0], id: 'missing' });
+    });
+
+    expect(result.current.atBats).toEqual(initialAtBats);
+    expect(warn).toHaveBeenCalledWith(
+      'At-bat id not found for update: missing'
+    );
+  });
+
+  test('should warn and preserve history when deleting a missing id', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useAtBatHistory(initialAtBats));
+
+    act(() => {
+      result.current.deleteAtBat('missing');
+    });
+
+    expect(result.current.atBats).toEqual(initialAtBats);
+    expect(warn).toHaveBeenCalledWith(
+      'At-bat id not found for deletion: missing'
+    );
   });
 });

--- a/src/hooks/__tests__/useAtBatHistory.test.ts
+++ b/src/hooks/__tests__/useAtBatHistory.test.ts
@@ -90,6 +90,15 @@ describe('useAtBatHistory', () => {
 
     expect(result.current.atBats).toEqual(initialAtBats);
     expect(warn).toHaveBeenCalledWith('Duplicate at-bat id ignored: ab1');
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should remove duplicate ids from initial history', () => {
+    const { result } = renderHook(() =>
+      useAtBatHistory([initialAtBats[0], { ...initialAtBats[0], result: 'HR' }])
+    );
+
+    expect(result.current.atBats).toEqual([initialAtBats[0]]);
   });
 
   test('should remove duplicate ids when resetting at-bats', () => {
@@ -118,6 +127,7 @@ describe('useAtBatHistory', () => {
     expect(warn).toHaveBeenCalledWith(
       'At-bat id not found for update: missing'
     );
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   test('should warn and preserve history when deleting a missing id', () => {
@@ -132,5 +142,6 @@ describe('useAtBatHistory', () => {
     expect(warn).toHaveBeenCalledWith(
       'At-bat id not found for deletion: missing'
     );
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useAtBatHistory.ts
+++ b/src/hooks/useAtBatHistory.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { AtBat } from '../types';
 
 const deduplicateAtBats = (
@@ -16,62 +16,70 @@ const deduplicateAtBats = (
   });
 };
 
+const hasAtBatId = (atBats: AtBat[], atBatId: string): boolean =>
+  atBats.some((atBat) => atBat.id === atBatId);
+
+const warn = (message: string): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(message);
+  }
+};
+
 export const useAtBatHistory = (initialAtBats: AtBat[]) => {
   const [atBats, setAtBats] = useState<AtBat[]>(() =>
     deduplicateAtBats(initialAtBats)
   );
+  const atBatsRef = useRef(atBats);
 
-  const warn = useCallback((message: string) => {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(message);
-    }
-  }, []);
+  const applyAtBatUpdate = useCallback(
+    (update: (previous: AtBat[]) => AtBat[]) => {
+      atBatsRef.current = update(atBatsRef.current);
+      setAtBats(update);
+    },
+    []
+  );
 
   const addAtBat = useCallback(
     (atBat: AtBat) => {
-      if (atBats.some((existing) => existing.id === atBat.id)) {
+      if (hasAtBatId(atBatsRef.current, atBat.id)) {
         warn(`Duplicate at-bat id ignored: ${atBat.id}`);
         return;
       }
-      setAtBats((prev) =>
-        prev.some((existing) => existing.id === atBat.id)
-          ? prev
-          : [...prev, atBat]
+      applyAtBatUpdate((prev) =>
+        hasAtBatId(prev, atBat.id) ? prev : [...prev, atBat]
       );
     },
-    [atBats, warn]
+    [applyAtBatUpdate]
   );
 
   const updateAtBat = useCallback(
     (updatedAtBat: AtBat) => {
-      if (!atBats.some((atBat) => atBat.id === updatedAtBat.id)) {
+      if (!hasAtBatId(atBatsRef.current, updatedAtBat.id)) {
         warn(`At-bat id not found for update: ${updatedAtBat.id}`);
-        return;
       }
-      setAtBats((prev) =>
-        prev.some((atBat) => atBat.id === updatedAtBat.id)
+      applyAtBatUpdate((prev) =>
+        hasAtBatId(prev, updatedAtBat.id)
           ? prev.map((atBat) =>
               atBat.id === updatedAtBat.id ? updatedAtBat : atBat
             )
           : prev
       );
     },
-    [atBats, warn]
+    [applyAtBatUpdate]
   );
 
   const deleteAtBat = useCallback(
     (atBatId: string) => {
-      if (!atBats.some((atBat) => atBat.id === atBatId)) {
+      if (!hasAtBatId(atBatsRef.current, atBatId)) {
         warn(`At-bat id not found for deletion: ${atBatId}`);
-        return;
       }
-      setAtBats((prev) =>
-        prev.some((atBat) => atBat.id === atBatId)
+      applyAtBatUpdate((prev) =>
+        hasAtBatId(prev, atBatId)
           ? prev.filter((atBat) => atBat.id !== atBatId)
           : prev
       );
     },
-    [atBats, warn]
+    [applyAtBatUpdate]
   );
 
   const resetAtBats = useCallback(
@@ -79,9 +87,9 @@ export const useAtBatHistory = (initialAtBats: AtBat[]) => {
       const uniqueAtBats = deduplicateAtBats(nextAtBats, (atBatId) =>
         warn(`Duplicate at-bat id ignored during reset: ${atBatId}`)
       );
-      setAtBats(uniqueAtBats);
+      applyAtBatUpdate(() => uniqueAtBats);
     },
-    [warn]
+    [applyAtBatUpdate]
   );
 
   return { atBats, addAtBat, updateAtBat, deleteAtBat, resetAtBats };

--- a/src/hooks/useAtBatHistory.ts
+++ b/src/hooks/useAtBatHistory.ts
@@ -1,8 +1,25 @@
 import { useState, useCallback } from 'react';
 import { AtBat } from '../types';
 
+const deduplicateAtBats = (
+  atBats: AtBat[],
+  onDuplicate?: (atBatId: string) => void
+): AtBat[] => {
+  const seenIds = new Set<string>();
+  return atBats.filter((atBat) => {
+    if (seenIds.has(atBat.id)) {
+      onDuplicate?.(atBat.id);
+      return false;
+    }
+    seenIds.add(atBat.id);
+    return true;
+  });
+};
+
 export const useAtBatHistory = (initialAtBats: AtBat[]) => {
-  const [atBats, setAtBats] = useState<AtBat[]>(initialAtBats);
+  const [atBats, setAtBats] = useState<AtBat[]>(() =>
+    deduplicateAtBats(initialAtBats)
+  );
 
   const warn = useCallback((message: string) => {
     if (process.env.NODE_ENV !== 'production') {
@@ -12,56 +29,56 @@ export const useAtBatHistory = (initialAtBats: AtBat[]) => {
 
   const addAtBat = useCallback(
     (atBat: AtBat) => {
-      setAtBats((prev) => {
-        if (prev.some((existing) => existing.id === atBat.id)) {
-          warn(`Duplicate at-bat id ignored: ${atBat.id}`);
-          return prev;
-        }
-        return [...prev, atBat];
-      });
+      if (atBats.some((existing) => existing.id === atBat.id)) {
+        warn(`Duplicate at-bat id ignored: ${atBat.id}`);
+        return;
+      }
+      setAtBats((prev) =>
+        prev.some((existing) => existing.id === atBat.id)
+          ? prev
+          : [...prev, atBat]
+      );
     },
-    [warn]
+    [atBats, warn]
   );
 
   const updateAtBat = useCallback(
     (updatedAtBat: AtBat) => {
-      setAtBats((prev) => {
-        if (!prev.some((atBat) => atBat.id === updatedAtBat.id)) {
-          warn(`At-bat id not found for update: ${updatedAtBat.id}`);
-          return prev;
-        }
-        return prev.map((atBat) =>
-          atBat.id === updatedAtBat.id ? updatedAtBat : atBat
-        );
-      });
+      if (!atBats.some((atBat) => atBat.id === updatedAtBat.id)) {
+        warn(`At-bat id not found for update: ${updatedAtBat.id}`);
+        return;
+      }
+      setAtBats((prev) =>
+        prev.some((atBat) => atBat.id === updatedAtBat.id)
+          ? prev.map((atBat) =>
+              atBat.id === updatedAtBat.id ? updatedAtBat : atBat
+            )
+          : prev
+      );
     },
-    [warn]
+    [atBats, warn]
   );
 
   const deleteAtBat = useCallback(
     (atBatId: string) => {
-      setAtBats((prev) => {
-        if (!prev.some((atBat) => atBat.id === atBatId)) {
-          warn(`At-bat id not found for deletion: ${atBatId}`);
-          return prev;
-        }
-        return prev.filter((atBat) => atBat.id !== atBatId);
-      });
+      if (!atBats.some((atBat) => atBat.id === atBatId)) {
+        warn(`At-bat id not found for deletion: ${atBatId}`);
+        return;
+      }
+      setAtBats((prev) =>
+        prev.some((atBat) => atBat.id === atBatId)
+          ? prev.filter((atBat) => atBat.id !== atBatId)
+          : prev
+      );
     },
-    [warn]
+    [atBats, warn]
   );
 
   const resetAtBats = useCallback(
     (nextAtBats: AtBat[]) => {
-      const seenIds = new Set<string>();
-      const uniqueAtBats = nextAtBats.filter((atBat) => {
-        if (seenIds.has(atBat.id)) {
-          warn(`Duplicate at-bat id ignored during reset: ${atBat.id}`);
-          return false;
-        }
-        seenIds.add(atBat.id);
-        return true;
-      });
+      const uniqueAtBats = deduplicateAtBats(nextAtBats, (atBatId) =>
+        warn(`Duplicate at-bat id ignored during reset: ${atBatId}`)
+      );
       setAtBats(uniqueAtBats);
     },
     [warn]

--- a/src/hooks/useAtBatHistory.ts
+++ b/src/hooks/useAtBatHistory.ts
@@ -4,19 +4,68 @@ import { AtBat } from '../types';
 export const useAtBatHistory = (initialAtBats: AtBat[]) => {
   const [atBats, setAtBats] = useState<AtBat[]>(initialAtBats);
 
-  const addAtBat = useCallback((atBat: AtBat) => {
-    setAtBats((prev) => [...prev, atBat]);
+  const warn = useCallback((message: string) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(message);
+    }
   }, []);
 
-  const updateAtBat = useCallback((updatedAtBat: AtBat) => {
-    setAtBats((prev) =>
-      prev.map((ab) => (ab.id === updatedAtBat.id ? updatedAtBat : ab))
-    );
-  }, []);
+  const addAtBat = useCallback(
+    (atBat: AtBat) => {
+      setAtBats((prev) => {
+        if (prev.some((existing) => existing.id === atBat.id)) {
+          warn(`Duplicate at-bat id ignored: ${atBat.id}`);
+          return prev;
+        }
+        return [...prev, atBat];
+      });
+    },
+    [warn]
+  );
 
-  const deleteAtBat = useCallback((atBatId: string) => {
-    setAtBats((prev) => prev.filter((ab) => ab.id !== atBatId));
-  }, []);
+  const updateAtBat = useCallback(
+    (updatedAtBat: AtBat) => {
+      setAtBats((prev) => {
+        if (!prev.some((atBat) => atBat.id === updatedAtBat.id)) {
+          warn(`At-bat id not found for update: ${updatedAtBat.id}`);
+          return prev;
+        }
+        return prev.map((atBat) =>
+          atBat.id === updatedAtBat.id ? updatedAtBat : atBat
+        );
+      });
+    },
+    [warn]
+  );
 
-  return { atBats, addAtBat, updateAtBat, deleteAtBat, setAtBats };
+  const deleteAtBat = useCallback(
+    (atBatId: string) => {
+      setAtBats((prev) => {
+        if (!prev.some((atBat) => atBat.id === atBatId)) {
+          warn(`At-bat id not found for deletion: ${atBatId}`);
+          return prev;
+        }
+        return prev.filter((atBat) => atBat.id !== atBatId);
+      });
+    },
+    [warn]
+  );
+
+  const resetAtBats = useCallback(
+    (nextAtBats: AtBat[]) => {
+      const seenIds = new Set<string>();
+      const uniqueAtBats = nextAtBats.filter((atBat) => {
+        if (seenIds.has(atBat.id)) {
+          warn(`Duplicate at-bat id ignored during reset: ${atBat.id}`);
+          return false;
+        }
+        seenIds.add(atBat.id);
+        return true;
+      });
+      setAtBats(uniqueAtBats);
+    },
+    [warn]
+  );
+
+  return { atBats, addAtBat, updateAtBat, deleteAtBat, resetAtBats };
 };

--- a/src/services/ScoreCalculator.ts
+++ b/src/services/ScoreCalculator.ts
@@ -13,6 +13,24 @@ export const NON_AT_BAT_RESULTS: readonly HitResult[] = [
   'SAC',
   'SF',
 ];
+export const OUT_RESULTS: readonly HitResult[] = [
+  'GO_P',
+  'GO_C',
+  'GO_1B',
+  'GO_2B',
+  'GO_3B',
+  'GO_SS',
+  'GO_RF',
+  'FO_LF',
+  'FO_CF',
+  'FO_RF',
+  'FO_IF',
+  'LO',
+  'DP',
+  'SO',
+  'SAC',
+  'SF',
+];
 
 export interface BattingStats {
   atBats: number;


### PR DESCRIPTION
## Summary
- prevent edit submissions without `onUpdateAtBat` from falling through to new-record creation
- reset result, memo, RBI, and status when editing ends externally
- centralize all out-result codes and align sacrifice icon color
- replace raw `setAtBats` exposure with duplicate-safe `resetAtBats`
- guard duplicate additions and warn on missing update/delete ids in development

## Verification
- `npm run ci:local` (23 suites, 136 tests)
- `MAX_BUNDLE_SIZE_MB=1.25 node scripts/check-bundle-size.js`
- `COVERAGE_THRESHOLD=30 node scripts/check-coverage.js`
- `npm audit --audit-level=high`

## Firebase / security impact
- no Firestore schema or security-rule changes
- no Firebase deployment in this PR; deployment follows the complete serial issue set

Closes #198