### PR TITLE
fix: stabilize game list async actions

### DIFF
--- a/src/components/GameList.tsx
+++ b/src/components/GameList.tsx
@@ -19,6 +19,8 @@ import {
   Switch,
   Tooltip,
   TextField,
+  Snackbar,
+  Alert,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -36,27 +38,23 @@ import { Game } from '../types';
 interface GameListProps {
   onSelectGame: (gameId: string) => void;
   onGameDeleted?: () => void;
-  onShareGame?: (gameId: string) => void;
 }
 
-const GameList: React.FC<GameListProps> = ({
-  onSelectGame,
-  onGameDeleted,
-  onShareGame,
-}) => {
+const GameList: React.FC<GameListProps> = ({ onSelectGame, onGameDeleted }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [games, setGames] = useState<Game[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [gameToDelete, setGameToDelete] = useState<string | null>(null);
   const [shareUrlDialogOpen, setShareUrlDialogOpen] = useState(false);
   const [shareUrl, setShareUrl] = useState('');
-  const [updatingPublicStatus, setUpdatingPublicStatus] = useState<
-    string | null
-  >(null);
+  const [updatingPublicStatus, setUpdatingPublicStatus] = useState<Set<string>>(
+    new Set()
+  );
 
   const fetchGames = async () => {
     try {
@@ -105,9 +103,9 @@ const GameList: React.FC<GameListProps> = ({
     if (!gameToDelete) return;
 
     try {
+      setActionError(null);
       await deleteGame(gameToDelete);
-      // 削除後にリストを更新
-      await fetchGames();
+      setGames((prev) => prev.filter((game) => game.id !== gameToDelete));
       // 親コンポーネントに通知
       if (onGameDeleted) {
         onGameDeleted();
@@ -116,33 +114,36 @@ const GameList: React.FC<GameListProps> = ({
       setGameToDelete(null);
     } catch (err) {
       console.error('Failed to delete game:', err);
-      setError('試合データの削除に失敗しました。');
+      setActionError('試合データの削除に失敗しました。');
     }
   };
 
   // 公開状態の切り替え
   const handleTogglePublic = async (
     gameId: string,
-    currentPublicStatus: boolean,
-    event: React.MouseEvent
+    nextPublicStatus: boolean,
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
     event.stopPropagation();
     try {
-      setUpdatingPublicStatus(gameId);
-      await updateGamePublicStatus(gameId, !currentPublicStatus);
+      setActionError(null);
+      setUpdatingPublicStatus((prev) => new Set(prev).add(gameId));
+      await updateGamePublicStatus(gameId, nextPublicStatus);
       // 状態を更新
-      setGames(
-        games.map((game) =>
-          game.id === gameId
-            ? { ...game, isPublic: !currentPublicStatus }
-            : game
+      setGames((prev) =>
+        prev.map((game) =>
+          game.id === gameId ? { ...game, isPublic: nextPublicStatus } : game
         )
       );
     } catch (err) {
       console.error('Failed to update public status:', err);
-      setError('公開設定の更新に失敗しました。');
+      setActionError('公開設定の更新に失敗しました。');
     } finally {
-      setUpdatingPublicStatus(null);
+      setUpdatingPublicStatus((prev) => {
+        const next = new Set(prev);
+        next.delete(gameId);
+        return next;
+      });
     }
   };
 
@@ -156,9 +157,9 @@ const GameList: React.FC<GameListProps> = ({
   };
 
   // URLをクリップボードにコピー
-  const handleCopyToClipboard = () => {
+  const handleCopyToClipboard = async () => {
     try {
-      navigator.clipboard.writeText(shareUrl);
+      await navigator.clipboard.writeText(shareUrl);
       alert('URLをクリップボードにコピーしました');
     } catch (err) {
       console.error('Failed to copy:', err);
@@ -207,11 +208,10 @@ const GameList: React.FC<GameListProps> = ({
                     <span>
                       <Switch
                         checked={Boolean(game.isPublic)}
-                        onChange={(e) => {}}
-                        onClick={(e) =>
-                          handleTogglePublic(game.id, Boolean(game.isPublic), e)
+                        onChange={(event, checked) =>
+                          handleTogglePublic(game.id, checked, event)
                         }
-                        disabled={updatingPublicStatus === game.id}
+                        disabled={updatingPublicStatus.has(game.id)}
                         color="primary"
                         size="small"
                         icon={<PublicOffIcon />}
@@ -268,7 +268,9 @@ const GameList: React.FC<GameListProps> = ({
                           {formatDate(game.date)}
                           {game.tournament && ` | ${game.tournament}`}
                           {game.venue && ` @ ${game.venue}`}
-                          {game.currentInning && ` | ${game.currentInning}回`}
+                          {game.currentInning > 0
+                            ? ` | ${game.currentInning}回`
+                            : ''}
                           {game.isPublic && ' | 公開中'}
                         </Typography>
                       )}
@@ -280,7 +282,9 @@ const GameList: React.FC<GameListProps> = ({
                         {formatDate(game.date)}
                         {game.tournament && ` | ${game.tournament}`}
                         {game.venue && ` @ ${game.venue}`}
-                        {game.currentInning && ` | ${game.currentInning}回`}
+                        {game.currentInning > 0
+                          ? ` | ${game.currentInning}回`
+                          : ''}
                         {game.isPublic && ' | 公開中'}
                       </>
                     ) : null
@@ -343,6 +347,16 @@ const GameList: React.FC<GameListProps> = ({
           <Button onClick={() => setShareUrlDialogOpen(false)}>閉じる</Button>
         </DialogActions>
       </Dialog>
+
+      <Snackbar
+        open={Boolean(actionError)}
+        autoHideDuration={6000}
+        onClose={() => setActionError(null)}
+      >
+        <Alert severity="error" onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      </Snackbar>
     </Paper>
   );
 };

--- a/src/components/__tests__/GameList.test.tsx
+++ b/src/components/__tests__/GameList.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import GameList from '../GameList';
+import {
+  getAllGames,
+  updateGamePublicStatus,
+} from '../../firebase/gameService';
+import { Game } from '../../types';
+
+jest.mock('../../firebase/gameService', () => ({
+  getAllGames: jest.fn(),
+  deleteGame: jest.fn(),
+  updateGamePublicStatus: jest.fn(),
+}));
+
+const mockedGetAllGames = getAllGames as jest.MockedFunction<
+  typeof getAllGames
+>;
+const mockedUpdateGamePublicStatus =
+  updateGamePublicStatus as jest.MockedFunction<typeof updateGamePublicStatus>;
+
+const makeGame = (id: string, overrides: Partial<Game> = {}): Game => ({
+  id,
+  date: '2026-08-22',
+  currentInning: 0,
+  tournament: '大会',
+  homeTeam: { id: `${id}-home`, name: `${id}ホーム`, players: [], atBats: [] },
+  awayTeam: {
+    id: `${id}-away`,
+    name: `${id}アウェイ`,
+    players: [],
+    atBats: [],
+  },
+  ...overrides,
+});
+
+const renderGameList = () =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <GameList onSelectGame={jest.fn()} />
+    </ThemeProvider>
+  );
+
+describe('GameList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('clipboardへのコピー失敗時は失敗メッセージだけを表示する', async () => {
+    mockedGetAllGames.mockResolvedValue([
+      makeGame('game-1', { isPublic: true }),
+    ]);
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const alert = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderGameList();
+
+    await user.click(
+      await screen.findByRole('button', { name: 'copy share link' })
+    );
+    await user.click(screen.getByRole('button', { name: 'URLをコピー' }));
+
+    await waitFor(() =>
+      expect(alert).toHaveBeenCalledWith(
+        'URLのコピーに失敗しました。手動でコピーしてください。'
+      )
+    );
+    expect(alert).not.toHaveBeenCalledWith(
+      'URLをクリップボードにコピーしました'
+    );
+  });
+
+  test('並行する公開切り替えの完了順が逆でも両方の状態を保持する', async () => {
+    mockedGetAllGames.mockResolvedValue([
+      makeGame('game-1'),
+      makeGame('game-2'),
+    ]);
+    const resolvers = new Map<string, () => void>();
+    mockedUpdateGamePublicStatus.mockImplementation(
+      (gameId) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(gameId, resolve);
+        })
+    );
+    const user = userEvent.setup();
+    renderGameList();
+
+    const switches = await screen.findAllByRole('checkbox');
+    await user.click(switches[0]);
+    await user.click(switches[1]);
+    resolvers.get('game-2')?.();
+    await waitFor(() => expect(switches[1]).toBeChecked());
+    resolvers.get('game-1')?.();
+
+    await waitFor(() => {
+      expect(switches[0]).toBeChecked();
+      expect(switches[1]).toBeChecked();
+    });
+  });
+
+  test('公開切り替え失敗時も試合一覧を表示し続ける', async () => {
+    mockedGetAllGames.mockResolvedValue([makeGame('game-1')]);
+    mockedUpdateGamePublicStatus.mockRejectedValue(new Error('offline'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+    renderGameList();
+
+    await user.click(await screen.findByRole('checkbox'));
+
+    expect(
+      await screen.findByText('公開設定の更新に失敗しました。')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('game-1アウェイ vs game-1ホーム')
+    ).toBeInTheDocument();
+  });
+
+  test('currentInningが0でも文字列の0を描画しない', async () => {
+    mockedGetAllGames.mockResolvedValue([makeGame('game-1')]);
+    const { container } = renderGameList();
+
+    await screen.findByText('game-1アウェイ vs game-1ホーム');
+    expect(container).not.toHaveTextContent('大会0');
+  });
+});


### PR DESCRIPTION
## Summary
- await clipboard writes so copy failures are reported accurately
- make public-status updates concurrency-safe with functional state updates
- keep the loaded game list visible when an action fails and suppress inning 0 labels
- remove the unused share callback and use the Switch change contract

## Verification
- `npm run ci:local` (24 suites, 144 tests)
- `MAX_BUNDLE_SIZE_MB=1.25 node scripts/check-bundle-size.js`
- `COVERAGE_THRESHOLD=30 node scripts/check-coverage.js`
- `npm audit --audit-level=high` (0 vulnerabilities)

No Firebase schema or rules changes.

Closes #199