### PR TITLE
fix: その他の得点・その他のアウトを表裏（タブ）のチームで正しくフィルタする

### DIFF
--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -1170,6 +1170,7 @@ const MainApp: React.FC<{
               <AtBatSummaryTable
                 team={currentTeam}
                 maxInning={currentInning}
+                isTop={tabIndex === 0}
                 outEvents={gameState.outEvents}
               />
             ) : (
@@ -1273,6 +1274,7 @@ const MainApp: React.FC<{
                       atBats={currentTeam.atBats}
                       players={currentTeam.players}
                       inning={currentInning}
+                      isTop={tabIndex === 0}
                       runEvents={gameState.runEvents}
                       outEvents={gameState.outEvents}
                       onEditAtBat={handleEditAtBat}

--- a/src/components/AtBatHistory.tsx
+++ b/src/components/AtBatHistory.tsx
@@ -23,6 +23,7 @@ interface AtBatHistoryProps {
   atBats: AtBat[];
   players: Player[];
   inning: number;
+  isTop: boolean; // 現在表示中のタブが表（true）か裏（false）か
   runEvents?: RunEvent[];
   outEvents?: OutEvent[];
   onEditAtBat?: (atBat: AtBat) => void;
@@ -74,6 +75,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
   atBats,
   players,
   inning,
+  isTop,
   runEvents = [],
   outEvents = [],
   onEditAtBat,
@@ -86,14 +88,14 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
   // 指定されたイニングの打席結果のみをフィルタリング
   const filteredAtBats = atBats.filter((atBat) => atBat.inning === inning);
 
-  // 指定されたイニングの得点イベントのみをフィルタリング
+  // 指定されたイニング・表裏の得点イベントのみをフィルタリング
   const filteredRunEvents = runEvents.filter(
-    (event) => event.inning === inning
+    (event) => event.inning === inning && event.isTop === isTop
   );
 
-  // 指定されたイニングのアウトイベントのみをフィルタリング
+  // 指定されたイニング・表裏のアウトイベントのみをフィルタリング
   const filteredOutEvents = outEvents.filter(
-    (event) => event.inning === inning
+    (event) => event.inning === inning && event.isTop === isTop
   );
 
   // 打席結果も得点イベントもアウトイベントもない場合

--- a/src/components/AtBatSummaryTable.tsx
+++ b/src/components/AtBatSummaryTable.tsx
@@ -31,6 +31,7 @@ import {
 interface AtBatSummaryTableProps {
   team: Team;
   maxInning: number;
+  isTop: boolean; // 表示中のチームが表（true）か裏（false）か
   outEvents?: OutEvent[];
 }
 
@@ -139,6 +140,7 @@ const formatOPS = (value: number): string => {
 const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
   team,
   maxInning,
+  isTop,
   outEvents = [],
 }): JSX.Element => {
   const theme = useTheme();
@@ -204,7 +206,7 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
 
   // イニングごとにアウトイベントがあるかどうかを確認
   const hasOutEventsForInning = (inning: number): boolean => {
-    return getOutEventsForInning(inning, true).length > 0;
+    return getOutEventsForInning(inning, isTop).length > 0;
   };
 
   // 打席結果を表示するセル（複数の結果に対応）
@@ -262,7 +264,7 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
 
   // アウトイベントを表示する行（デスクトップ表示用）
   const renderOutEventRow = (inning: number) => {
-    const outEvents = getOutEventsForInning(inning, true);
+    const outEvents = getOutEventsForInning(inning, isTop);
     if (!outEvents.length) return null;
 
     return (
@@ -413,7 +415,7 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
                   回のその他のアウト:
                 </Typography>
                 <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                  {getOutEventsForInning(inning, true).map((event) => (
+                  {getOutEventsForInning(inning, isTop).map((event) => (
                     <Tooltip
                       key={event.id}
                       title={`${event.outType}${event.note ? ` - ${event.note}` : ''}`}
@@ -434,11 +436,11 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
                   ))}
                 </Stack>
                 {/* 注記があれば表示 */}
-                {getOutEventsForInning(inning, true).some(
+                {getOutEventsForInning(inning, isTop).some(
                   (event) => event.note
                 ) && (
                   <Box sx={{ mt: 1, pl: 1, borderLeft: '2px solid #e0e0e0' }}>
-                    {getOutEventsForInning(inning, true)
+                    {getOutEventsForInning(inning, isTop)
                       .filter((event) => event.note)
                       .map((event) => (
                         <Typography

--- a/src/components/__tests__/AtBatHistory.test.tsx
+++ b/src/components/__tests__/AtBatHistory.test.tsx
@@ -59,7 +59,12 @@ const mockAtBats: AtBat[] = [
 describe('AtBatHistory', () => {
   test('displays at-bat records correctly', () => {
     render(
-      <AtBatHistory atBats={mockAtBats} players={mockPlayers} inning={1} />
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+      />
     );
 
     // 1イニングの打席記録が表示されることを確認（名前と守備位置を含む）
@@ -71,7 +76,12 @@ describe('AtBatHistory', () => {
 
   test('filters at-bats by inning', () => {
     render(
-      <AtBatHistory atBats={mockAtBats} players={mockPlayers} inning={2} />
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={2}
+        isTop={true}
+      />
     );
 
     // 2イニングの記録のみ表示
@@ -101,6 +111,7 @@ describe('AtBatHistory', () => {
         atBats={atBatsWithUnknownPlayer}
         players={mockPlayers}
         inning={1}
+        isTop={true}
       />
     );
 
@@ -115,6 +126,7 @@ describe('AtBatHistory', () => {
         atBats={mockAtBats}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         onEditAtBat={handleEdit}
       />
     );
@@ -134,6 +146,7 @@ describe('AtBatHistory', () => {
         atBats={mockAtBats}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         onDeleteAtBat={handleDelete}
       />
     );
@@ -148,7 +161,12 @@ describe('AtBatHistory', () => {
 
   test('does not show edit/delete buttons when handlers are not provided', () => {
     render(
-      <AtBatHistory atBats={mockAtBats} players={mockPlayers} inning={1} />
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+      />
     );
 
     expect(screen.queryByLabelText('編集')).not.toBeInTheDocument();
@@ -157,7 +175,12 @@ describe('AtBatHistory', () => {
 
   test('displays memo when provided', () => {
     render(
-      <AtBatHistory atBats={mockAtBats} players={mockPlayers} inning={1} />
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+      />
     );
 
     // memoカラムに「センターに抜けた」が表示される、もしくは詳細カラムに表示
@@ -167,7 +190,12 @@ describe('AtBatHistory', () => {
 
   test('displays message when no at-bats for the inning', () => {
     render(
-      <AtBatHistory atBats={mockAtBats} players={mockPlayers} inning={5} />
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={5}
+        isTop={true}
+      />
     );
 
     expect(screen.getByText(/まだ記録がありません/)).toBeInTheDocument();
@@ -191,6 +219,7 @@ describe('AtBatHistory', () => {
         atBats={[]}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         runEvents={runEvents}
       />
     );
@@ -217,6 +246,7 @@ describe('AtBatHistory', () => {
         atBats={[]}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         outEvents={outEvents}
       />
     );
@@ -245,6 +275,7 @@ describe('AtBatHistory', () => {
         atBats={[]}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         runEvents={runEvents}
         onDeleteRunEvent={handleDeleteRunEvent}
       />
@@ -274,6 +305,7 @@ describe('AtBatHistory', () => {
         atBats={[]}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         outEvents={outEvents}
         onDeleteOutEvent={handleDeleteOutEvent}
       />
@@ -303,6 +335,7 @@ describe('AtBatHistory', () => {
         atBats={[]}
         players={mockPlayers}
         inning={1}
+        isTop={true}
         runEvents={runEvents}
         currentTeamName="ホークス"
         opposingTeamName="タイガース"
@@ -312,5 +345,98 @@ describe('AtBatHistory', () => {
     // チーム名はテーブルヘッダーやイベントの説明で使用される可能性がある
     // ここでは最低限レンダリングできることを確認
     expect(screen.getByText('その他の得点')).toBeInTheDocument();
+  });
+
+  test('表のイベントのみを表示し、裏のイベントは表示しない', () => {
+    const runEvents = [
+      {
+        id: 're-top',
+        inning: 1,
+        isTop: true,
+        runType: '押し出し' as const,
+        runCount: 1,
+        note: '表チームの得点',
+        timestamp: new Date(),
+      },
+      {
+        id: 're-bottom',
+        inning: 1,
+        isTop: false,
+        runType: '押し出し' as const,
+        runCount: 1,
+        note: '裏チームの得点',
+        timestamp: new Date(),
+      },
+    ];
+    const outEvents = [
+      {
+        id: 'oe-top',
+        inning: 1,
+        isTop: true,
+        outType: '牽制アウト' as const,
+        note: '表チームのアウト',
+        timestamp: new Date(),
+      },
+      {
+        id: 'oe-bottom',
+        inning: 1,
+        isTop: false,
+        outType: '牽制アウト' as const,
+        note: '裏チームのアウト',
+        timestamp: new Date(),
+      },
+    ];
+
+    render(
+      <AtBatHistory
+        atBats={[]}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+        runEvents={runEvents}
+        outEvents={outEvents}
+      />
+    );
+
+    expect(screen.getByText('表チームの得点')).toBeInTheDocument();
+    expect(screen.queryByText('裏チームの得点')).not.toBeInTheDocument();
+    expect(screen.getByText('表チームのアウト')).toBeInTheDocument();
+    expect(screen.queryByText('裏チームのアウト')).not.toBeInTheDocument();
+  });
+
+  test('裏のタブでは裏のイベントのみを表示する', () => {
+    const runEvents = [
+      {
+        id: 're-top',
+        inning: 1,
+        isTop: true,
+        runType: '押し出し' as const,
+        runCount: 1,
+        note: '表チームの得点',
+        timestamp: new Date(),
+      },
+      {
+        id: 're-bottom',
+        inning: 1,
+        isTop: false,
+        runType: '押し出し' as const,
+        runCount: 1,
+        note: '裏チームの得点',
+        timestamp: new Date(),
+      },
+    ];
+
+    render(
+      <AtBatHistory
+        atBats={[]}
+        players={mockPlayers}
+        inning={1}
+        isTop={false}
+        runEvents={runEvents}
+      />
+    );
+
+    expect(screen.getByText('裏チームの得点')).toBeInTheDocument();
+    expect(screen.queryByText('表チームの得点')).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/AtBatSummaryTable.test.tsx
+++ b/src/components/__tests__/AtBatSummaryTable.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import AtBatSummaryTable from '../AtBatSummaryTable';
+import { Team, OutEvent } from '../../types';
+
+const team: Team = {
+  id: 'team-1',
+  name: '後攻チーム',
+  players: [
+    {
+      id: 'p1',
+      name: '選手1',
+      number: '1',
+      position: 'CF',
+      isActive: true,
+      order: 1,
+    },
+  ],
+  atBats: [],
+};
+
+const outEvents: OutEvent[] = [
+  {
+    id: 'oe-top',
+    inning: 1,
+    isTop: true,
+    outType: '牽制アウト',
+    note: '表チームのアウト',
+    timestamp: new Date(),
+  },
+  {
+    id: 'oe-bottom',
+    inning: 1,
+    isTop: false,
+    outType: 'タッチアウト',
+    note: '裏チームのアウト',
+    timestamp: new Date(),
+  },
+];
+
+const renderTable = (isTop: boolean) =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <AtBatSummaryTable
+        team={team}
+        maxInning={1}
+        isTop={isTop}
+        outEvents={outEvents}
+      />
+    </ThemeProvider>
+  );
+
+describe('AtBatSummaryTable', () => {
+  test('表のタブでは表のアウトイベントのみを表示する', () => {
+    renderTable(true);
+
+    expect(
+      screen.getByLabelText('牽制アウト - 表チームのアウト')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('タッチアウト - 裏チームのアウト')
+    ).not.toBeInTheDocument();
+  });
+
+  test('裏のタブでは裏のアウトイベントのみを表示する', () => {
+    renderTable(false);
+
+    expect(
+      screen.getByLabelText('タッチアウト - 裏チームのアウト')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('牽制アウト - 表チームのアウト')
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Closes #224

「N回の記録」の「その他の得点」「その他のアウト」、および一覧表示モードの
`AtBatSummaryTable` が表裏（`isTop`）でフィルタされておらず、表裏どちらの
タブでも同じイベントが混在表示されていた。

## 原因
- `AtBatHistory` の `filteredRunEvents` / `filteredOutEvents` が `inning` のみで
  フィルタしており、`isTop` の判定がなかった。
- `AtBatSummaryTable` の `getOutEventsForInning` 呼び出しがすべて `isTop=true`
  にハードコードされており、後攻（ホーム）チームのタブでは先攻チームのアウト
  イベントが表示され、後攻チーム自身のイベントはどこにも表示されなかった。

## 変更内容
- `AtBatHistory` に必須 prop `isTop` を追加し、`runEvents` / `outEvents` の
  フィルタ条件に `event.isTop === isTop` を追加（`src/components/AtBatHistory.tsx`）。
- `AtBatSummaryTable` に必須 prop `isTop` を追加し、`getOutEventsForInning` の
  全呼び出し箇所のハードコードされた `true` を `isTop` に置き換え
  （`src/components/AtBatSummaryTable.tsx`）。
- `MainApp` から両コンポーネントへ `isTop={tabIndex === 0}` を渡すように変更
  （`src/MainApp.tsx`）。

`AtBatHistory` の `currentTeamName` / `opposingTeamName` は元々未使用の
デッド props だったため、今回のスコープでは変更していません（別 issue の対象）。

## 受け入れ基準
- [x] 表のタブでは表のチームのイベントのみ、裏のタブでは裏のチームのイベント
      のみが表示される
- [x] `AtBatSummaryTable` で後攻チームのタブに後攻チームのアウトイベントが
      表示される
- [x] 表裏それぞれのイベントでフィルタされることを検証するユニットテストが
      追加される

## テスト
- `src/components/__tests__/AtBatHistory.test.tsx`: 表裏それぞれのタブで
  相手側のイベントが表示されないことを検証する2ケースを追加。既存ケースは
  必須になった `isTop` prop を明示するよう更新。
- `src/components/__tests__/AtBatSummaryTable.test.tsx`（新規）: 表裏それぞれの
  タブで自チームのアウトイベントのみが表示されることを検証。
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check` ✅
- `npm test -- --watchAll=false`（27 suites / 158 tests）✅
- `npm run build` ✅

## 確認できなかった検証
- `npm start` によるデスクトップ／モバイル目視確認: このローカル環境では
  `react-scripts start` が既存の `webpack-dev-server` オプション不整合で
  クラッシュするため実行不可（#223 の PR で報告済み、本 PR の変更とは無関係）。
  本番ビルドは実 Firebase ログインが必要なため、ログイン後の画面での目視確認は
  未実施。上記のユニットテストで表裏フィルタの回帰確認を行った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)