### PR TITLE
fix: 試合データの損失防止（新規試合リセットの確認・自動保存・Undo の接続）

### DIFF
--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import MainApp from './MainApp';
+
+let mockUuidCounter = 0;
+jest.mock('uuid', () => ({ v4: () => `test-uuid-${mockUuidCounter++}` }));
+
+jest.mock('./contexts/AuthContext', () => ({
+  useAuth: () => ({
+    currentUser: { uid: 'test-user', email: 'test@example.com' },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('./firebase/gameService', () => ({
+  saveGame: jest.fn(),
+  getGameById: jest.fn(),
+  getSharedGameById: jest.fn().mockResolvedValue(null),
+  saveGameAsNew: jest.fn(),
+}));
+
+jest.mock('./firebase/teamService', () => ({
+  getTeamById: jest.fn(),
+  getUserTeams: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('./firebase/analyticsClient', () => ({
+  logAnalyticsEvent: jest.fn(),
+}));
+
+const renderMainApp = () =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MainApp toggleColorMode={jest.fn()} mode="light" />
+    </ThemeProvider>
+  );
+
+// 打席登録ボタンを選手名から特定して押す
+const registerAtBatFor = async (
+  user: ReturnType<typeof userEvent.setup>,
+  playerName: string
+) => {
+  const nameCell = await screen.findByText(playerName);
+  const row = nameCell.closest('tr');
+  if (!row) throw new Error(`row for ${playerName} not found`);
+  await user.click(within(row).getByRole('button', { name: '打席登録' }));
+};
+
+const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: 'メニューを開く' }));
+};
+
+// 打席を登録してダイアログを閉じるところまで実行する
+const registerAndSubmitAtBat = async (
+  user: ReturnType<typeof userEvent.setup>,
+  playerName: string
+) => {
+  await registerAtBatFor(user, playerName);
+  await screen.findByRole('heading', { name: /打席結果登録/ });
+  await user.click(screen.getByRole('button', { name: '登録' }));
+};
+
+describe('MainApp - 試合データの損失防止', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('未保存の変更がない状態で「新しい試合」を選ぶと確認なしでリセットされる', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: /新しい試合/ }));
+
+    // 確認ダイアログは表示されない
+    expect(
+      screen.queryByText('保存されていない変更があります')
+    ).not.toBeInTheDocument();
+  }, 15000);
+
+  test('未保存の変更がある状態で「新しい試合」を選ぶと確認ダイアログが出て、キャンセルするとデータが残る', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    // 選手1の打席を登録して未保存の変更を作る
+    await registerAndSubmitAtBat(user, '選手1');
+    await screen.findByRole('button', { name: '編集' });
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: /新しい試合/ }));
+
+    const dialogTitle =
+      await screen.findByText('保存されていない変更があります');
+    expect(dialogTitle).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    // ダイアログが閉じ、打席記録は残っている
+    await waitFor(() => {
+      expect(
+        screen.queryByText('保存されていない変更があります')
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+  }, 15000);
+
+  test('確認ダイアログで「新しい試合を開始」を選ぶと打席記録がリセットされる', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await registerAndSubmitAtBat(user, '選手1');
+    await screen.findByRole('button', { name: '編集' });
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: /新しい試合/ }));
+    await screen.findByText('保存されていない変更があります');
+
+    await user.click(screen.getByRole('button', { name: '新しい試合を開始' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('保存されていない変更があります')
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('button', { name: '編集' })
+    ).not.toBeInTheDocument();
+  }, 15000);
+
+  test('「元に戻す」で打席登録を取り消し、「やり直す」で再度反映できる', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await registerAndSubmitAtBat(user, '選手1');
+    await screen.findByRole('button', { name: '編集' });
+
+    await user.click(screen.getByRole('button', { name: '元に戻す' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: '編集' })
+      ).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'やり直す' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+    });
+  }, 15000);
+
+  test('リロードを想定した再マウント時に下書きの復元を提案する', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderMainApp();
+
+    await registerAndSubmitAtBat(user, '選手1');
+    await screen.findByRole('button', { name: '編集' });
+
+    // デバウンス後に下書きが localStorage に保存されるのを待つ
+    await waitFor(
+      () => {
+        expect(
+          localStorage.getItem('baseball-score:draft:test-user')
+        ).not.toBeNull();
+      },
+      { timeout: 3000 }
+    );
+
+    unmount();
+
+    // リロード相当の再マウント
+    renderMainApp();
+
+    const restoreDialog =
+      await screen.findByText('前回の入力途中の試合があります');
+    expect(restoreDialog).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '復元する' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+    });
+  }, 15000);
+});

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -1,5 +1,12 @@
 /* istanbul ignore file */
-import React, { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  lazy,
+  Suspense,
+} from 'react';
 import {
   Container,
   AppBar,
@@ -43,6 +50,8 @@ import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import UndoIcon from '@mui/icons-material/Undo';
+import RedoIcon from '@mui/icons-material/Redo';
 import { v4 as uuidv4 } from 'uuid';
 import {
   Team,
@@ -121,7 +130,11 @@ const MainApp: React.FC<{
   const { currentUser, isLoading } = useAuth();
   const theme = useTheme();
   const initialGame = useMemo(() => createInitialGame(), []);
-  const { state: gameState, actions: gameActions } = useGameState(initialGame);
+  const {
+    state: gameState,
+    actions: gameActions,
+    history: gameHistory,
+  } = useGameState(initialGame);
   const { loadGame } = gameActions;
   const { homeTeam, awayTeam, currentInning, isTop } = gameState;
 
@@ -161,6 +174,20 @@ const MainApp: React.FC<{
 
   // 場所と大会名設定関連の状態
   const [venueDialogOpen, setVenueDialogOpen] = useState(false);
+
+  // 未保存の変更検知・「新しい試合」確認ダイアログ関連の状態
+  // resetGame/loadGame の直後に発火する gameState 変更を「変更なし」として
+  // 扱うためのフラグ（保存済みスナップショットの更新をスキップしない対象）
+  const pendingBaselineResetRef = useRef(false);
+  const [savedSnapshot, setSavedSnapshot] = useState<string>(() =>
+    JSON.stringify(gameState)
+  );
+  const [newGameConfirmOpen, setNewGameConfirmOpen] = useState(false);
+  const hasUnsavedChanges = JSON.stringify(gameState) !== savedSnapshot;
+
+  // 下書きの自動保存・復元関連の状態
+  const [draftRestoreAvailable, setDraftRestoreAvailable] = useState(false);
+  const draftRestoreDataRef = useRef<Game | null>(null);
 
   // 現在選択されているチーム
   const currentTeam = tabIndex === 0 ? awayTeam : homeTeam;
@@ -220,6 +247,7 @@ const MainApp: React.FC<{
           const sharedGame = await getSharedGameById(sharedGameId);
           if (sharedGame) {
             console.log('Successfully loaded shared game:', sharedGameId);
+            pendingBaselineResetRef.current = true;
             loadGame(sharedGame);
             setIsSharedMode(true);
             setActiveStep(1); // 共有リンクでは自動的に一覧表示モードに
@@ -250,6 +278,105 @@ const MainApp: React.FC<{
 
     checkSharedGame();
   }, [loadGame]);
+
+  // 新しい試合の作成・試合の読み込み直後は、その内容を「未保存の変更なし」の
+  // 基準として記録し直す
+  useEffect(() => {
+    if (pendingBaselineResetRef.current) {
+      pendingBaselineResetRef.current = false;
+      setSavedSnapshot(JSON.stringify(gameState));
+    }
+  }, [gameState]);
+
+  // 下書きの保存先キー（ユーザーごとに分離し、共用端末での混在を避ける）
+  const draftStorageKey = currentUser
+    ? `baseball-score:draft:${currentUser.uid}`
+    : null;
+
+  // 起動時（ログイン直後）に、前回保存されなかった下書きが残っていないか確認する
+  useEffect(() => {
+    if (!draftStorageKey) return;
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('gameId')) {
+      // 共有リンクからの読み込みを優先する
+      return;
+    }
+
+    try {
+      const raw = localStorage.getItem(draftStorageKey);
+      if (!raw) return;
+
+      const draftGame = JSON.parse(raw) as Game;
+      const hasContent =
+        (draftGame.homeTeam?.atBats?.length ?? 0) > 0 ||
+        (draftGame.awayTeam?.atBats?.length ?? 0) > 0 ||
+        (draftGame.runEvents?.length ?? 0) > 0 ||
+        (draftGame.outEvents?.length ?? 0) > 0;
+
+      if (hasContent) {
+        draftRestoreDataRef.current = draftGame;
+        setDraftRestoreAvailable(true);
+      } else {
+        localStorage.removeItem(draftStorageKey);
+      }
+    } catch (error) {
+      console.error('Failed to read draft from localStorage:', error);
+    }
+    // draftStorageKey が確定した最初のタイミングでのみ確認する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftStorageKey]);
+
+  // gameState の変更を一定時間デバウンスして下書きとして localStorage に保存する
+  useEffect(() => {
+    if (!draftStorageKey || isSharedMode) return;
+
+    const timer = setTimeout(() => {
+      try {
+        const draftGame: Game = {
+          id: gameState.id,
+          date: gameState.date,
+          venue: gameState.venue,
+          tournament: gameState.tournament,
+          homeTeam: gameState.homeTeam,
+          awayTeam: gameState.awayTeam,
+          currentInning: gameState.currentInning,
+          isTop: gameState.isTop,
+          runEvents: gameState.runEvents,
+          outEvents: gameState.outEvents,
+          lastUpdated: new Date().toISOString(),
+        };
+        localStorage.setItem(draftStorageKey, JSON.stringify(draftGame));
+      } catch (error) {
+        console.error('Failed to save draft to localStorage:', error);
+      }
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [gameState, draftStorageKey, isSharedMode]);
+
+  // 下書きを復元する
+  const handleRestoreDraft = () => {
+    const draftGame = draftRestoreDataRef.current;
+    if (draftGame) {
+      pendingBaselineResetRef.current = true;
+      loadGame(draftGame);
+      setSnackbarOpen(true);
+      setSnackbarMessage('前回の入力途中の試合を復元しました');
+      setSnackbarSeverity('info');
+    }
+    draftRestoreDataRef.current = null;
+    setDraftRestoreAvailable(false);
+  };
+
+  // 下書きを破棄する
+  const handleDiscardDraft = () => {
+    if (draftStorageKey) {
+      localStorage.removeItem(draftStorageKey);
+    }
+    draftRestoreDataRef.current = null;
+    setDraftRestoreAvailable(false);
+  };
 
   // ローディング中表示
   if (sharedGameLoading || isLoading) {
@@ -430,8 +557,9 @@ const MainApp: React.FC<{
     handleMenuClose();
   };
 
-  // 新しい試合を作成
-  const handleNewGame = () => {
+  // 新しい試合を実際に作成する（確認済み、または未保存の変更がない場合）
+  const performNewGame = () => {
+    pendingBaselineResetRef.current = true;
     gameActions.resetGame();
     handleMenuClose();
     // 試合一覧画面が表示されている場合は閉じる
@@ -448,6 +576,27 @@ const MainApp: React.FC<{
     }
     // チーム選択ダイアログを表示せず、直接新しい試合画面に遷移
     // showTeamSelectionDialog();
+  };
+
+  // 新しい試合を作成（未保存の変更がある場合は確認ダイアログを挟む）
+  const handleNewGame = () => {
+    if (hasUnsavedChanges) {
+      setNewGameConfirmOpen(true);
+      handleMenuClose();
+      return;
+    }
+    performNewGame();
+  };
+
+  // 「新しい試合」確認ダイアログで実行を選んだ
+  const handleConfirmNewGame = () => {
+    setNewGameConfirmOpen(false);
+    performNewGame();
+  };
+
+  // 「新しい試合」確認ダイアログをキャンセルした
+  const handleCancelNewGame = () => {
+    setNewGameConfirmOpen(false);
   };
 
   // 表示モードの切り替え
@@ -519,6 +668,10 @@ const MainApp: React.FC<{
       let gameId: string;
       let message: string;
 
+      // 保存成功後に setGameId で変わる gameState を「未保存の変更なし」の
+      // 基準として扱う
+      pendingBaselineResetRef.current = true;
+
       if (saveAsNew) {
         // 新しい試合データとして保存
         gameId = await saveGameAsNew(gameToSave);
@@ -547,6 +700,11 @@ const MainApp: React.FC<{
 
       // 最後に保存した試合のIDをローカルストレージに保存
       localStorage.setItem('lastGameId', gameId);
+
+      // Firestoreへの保存に成功したので、ローカルの下書きは不要になる
+      if (draftStorageKey) {
+        localStorage.removeItem(draftStorageKey);
+      }
 
       // 保存ダイアログを閉じる
       setSaveDialogOpen(false);
@@ -599,6 +757,7 @@ const MainApp: React.FC<{
     try {
       const loadedGame = await getGameById(gameId);
       if (loadedGame) {
+        pendingBaselineResetRef.current = true;
         loadGame(loadedGame);
         setSnackbarMessage('試合データを読み込みました');
         setSnackbarSeverity('success');
@@ -1231,6 +1390,32 @@ const MainApp: React.FC<{
                       アウト追加
                     </Button>
                   </Stack>
+                  <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    spacing={1.5}
+                    sx={{ width: '100%', mt: 1.5 }}
+                  >
+                    <Button
+                      variant="outlined"
+                      onClick={gameHistory.undo}
+                      disabled={!gameHistory.canUndo}
+                      startIcon={<UndoIcon />}
+                      fullWidth={isMobile}
+                      sx={{ minHeight: isMobile ? 48 : 40 }}
+                    >
+                      元に戻す
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={gameHistory.redo}
+                      disabled={!gameHistory.canRedo}
+                      startIcon={<RedoIcon />}
+                      fullWidth={isMobile}
+                      sx={{ minHeight: isMobile ? 48 : 40 }}
+                    >
+                      やり直す
+                    </Button>
+                  </Stack>
                 </SectionCard>
 
                 <SectionCard title="選手一覧">
@@ -1508,6 +1693,39 @@ const MainApp: React.FC<{
         </DialogContent>
         <DialogActions>
           <Button onClick={closeTeamSelectionDialog}>キャンセル</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 新しい試合の確認ダイアログ（未保存の変更がある場合） */}
+      <Dialog open={newGameConfirmOpen} onClose={handleCancelNewGame}>
+        <DialogTitle>保存されていない変更があります</DialogTitle>
+        <DialogContent>
+          <Typography>
+            現在の試合データは保存されていません。新しい試合を開始すると、
+            この内容は失われます。よろしいですか？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelNewGame}>キャンセル</Button>
+          <Button onClick={handleConfirmNewGame} color="error">
+            新しい試合を開始
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 下書き復元の確認ダイアログ */}
+      <Dialog open={draftRestoreAvailable} onClose={handleDiscardDraft}>
+        <DialogTitle>前回の入力途中の試合があります</DialogTitle>
+        <DialogContent>
+          <Typography>
+            保存されていない試合データが見つかりました。復元しますか？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDiscardDraft}>破棄する</Button>
+          <Button onClick={handleRestoreDraft} color="primary" autoFocus>
+            復元する
+          </Button>
         </DialogActions>
       </Dialog>
 

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -320,4 +320,106 @@ describe('useGameState', () => {
     expect(result.current.state.venue).toBe('Tokyo Dome');
     expect(result.current.state.tournament).toBe('Winter Cup');
   });
+
+  test('history.undo/redo can revert and reapply addAtBat', () => {
+    const { result } = renderHook(() => useGameState());
+
+    act(() => {
+      result.current.actions.setAwayTeam({
+        id: 'test-team',
+        name: 'Test Team',
+        players: [
+          {
+            id: 'p1',
+            name: 'Player 1',
+            number: '1',
+            position: 'P',
+            isActive: true,
+            order: 1,
+          },
+        ],
+        atBats: [],
+      });
+    });
+
+    // setAwayTeam 自体も履歴に積まれる
+    expect(result.current.history.canUndo).toBe(true);
+
+    const atBat: AtBat = {
+      id: 'atbat1',
+      playerId: 'p1',
+      result: 'IH',
+      inning: 1,
+      isTop: true,
+      rbi: 0,
+      isOut: false,
+    };
+
+    act(() => {
+      result.current.actions.addAtBat(atBat);
+    });
+
+    expect(result.current.state.awayTeam.atBats).toHaveLength(1);
+    expect(result.current.history.canUndo).toBe(true);
+    expect(result.current.history.canRedo).toBe(false);
+
+    act(() => {
+      result.current.history.undo();
+    });
+
+    expect(result.current.state.awayTeam.atBats).toHaveLength(0);
+    expect(result.current.history.canRedo).toBe(true);
+
+    act(() => {
+      result.current.history.redo();
+    });
+
+    expect(result.current.state.awayTeam.atBats).toHaveLength(1);
+    expect(result.current.state.awayTeam.atBats[0].id).toBe('atbat1');
+  });
+
+  test('resetGame and loadGame clear the undo/redo history', () => {
+    const { result } = renderHook(() => useGameState());
+
+    act(() => {
+      result.current.actions.updateInning(3, false);
+    });
+    expect(result.current.history.canUndo).toBe(true);
+
+    act(() => {
+      result.current.actions.resetGame();
+    });
+    expect(result.current.history.canUndo).toBe(false);
+    expect(result.current.history.canRedo).toBe(false);
+
+    act(() => {
+      result.current.actions.updateInning(2, false);
+    });
+    expect(result.current.history.canUndo).toBe(true);
+
+    act(() => {
+      result.current.actions.loadGame({
+        id: 'game-1',
+        date: '2025-01-01',
+        venue: '',
+        tournament: '',
+        homeTeam: {
+          id: 'home',
+          name: 'Home Team',
+          players: [],
+          atBats: [],
+        },
+        awayTeam: {
+          id: 'away',
+          name: 'Away Team',
+          players: [],
+          atBats: [],
+        },
+        currentInning: 1,
+        isTop: true,
+      } as Game);
+    });
+    expect(result.current.history.canUndo).toBe(false);
+    expect(result.current.history.canRedo).toBe(false);
+  });
 });

--- a/src/hooks/__tests__/useUndoRedo.test.ts
+++ b/src/hooks/__tests__/useUndoRedo.test.ts
@@ -219,4 +219,44 @@ describe('useUndoRedo', () => {
     expect(result.current.canUndo).toBe(false);
     expect(result.current.canRedo).toBe(false);
   });
+
+  it('should accept an updater function like React setState', () => {
+    const { result } = renderHook(() => useUndoRedo({ count: 0 }));
+
+    act(() => {
+      result.current.set((prev) => ({ count: prev.count + 1 }));
+      result.current.set((prev) => ({ count: prev.count + 1 }));
+    });
+
+    expect(result.current.state).toEqual({ count: 2 });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.state).toEqual({ count: 1 });
+  });
+
+  it('should cap history length so memory does not grow without bound', () => {
+    const { result } = renderHook(() => useUndoRedo({ count: 0 }));
+
+    act(() => {
+      // 上限（50）を超える回数、状態を更新する
+      for (let i = 1; i <= 60; i += 1) {
+        result.current.set({ count: i });
+      }
+    });
+
+    expect(result.current.state).toEqual({ count: 60 });
+
+    // 何度 undo しても、破棄された履歴より前には戻れない
+    act(() => {
+      for (let i = 0; i < 60; i += 1) {
+        result.current.undo();
+      }
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.state).toEqual({ count: 10 });
+  });
 });

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Game, Team, AtBat, RunEvent, OutEvent } from '../types';
+import { useUndoRedo } from './useUndoRedo';
 
 type RunnerState = { first: boolean; second: boolean; third: boolean };
 
@@ -37,9 +38,18 @@ export interface GameStateActions {
   loadGame: (game: Game) => void;
 }
 
+// 打席登録・削除、得点/アウトイベント追加などの取り消し・やり直し操作
+export interface GameStateHistory {
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+}
+
 export interface UseGameStateReturn {
   state: GameState;
   actions: GameStateActions;
+  history: GameStateHistory;
 }
 
 const emptyRunners = (): RunnerState => ({
@@ -142,185 +152,238 @@ const advanceRunners = (runners: RunnerState, bases: number): RunnerState => {
 };
 
 export const useGameState = (initialGame?: Game): UseGameStateReturn => {
-  const [state, setState] = useState<GameState>(() =>
-    buildInitialState(initialGame)
+  const {
+    state,
+    set: setState,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset: resetHistory,
+  } = useUndoRedo<GameState>(buildInitialState(initialGame));
+
+  const setHomeTeam = useCallback(
+    (team: Team) => {
+      setState((prev) => ({
+        ...prev,
+        homeTeam: normalizeTeam(team),
+      }));
+    },
+    [setState]
   );
 
-  const setHomeTeam = useCallback((team: Team) => {
-    setState((prev) => ({
-      ...prev,
-      homeTeam: normalizeTeam(team),
-    }));
-  }, []);
-
-  const setAwayTeam = useCallback((team: Team) => {
-    setState((prev) => ({
-      ...prev,
-      awayTeam: normalizeTeam(team),
-    }));
-  }, []);
-
-  const setGameId = useCallback((id: string) => {
-    setState((prev) => ({
-      ...prev,
-      id,
-    }));
-  }, []);
-
-  const setDate = useCallback((date: string) => {
-    setState((prev) => ({
-      ...prev,
-      date,
-    }));
-  }, []);
-
-  const setVenue = useCallback((venue: string) => {
-    setState((prev) => ({
-      ...prev,
-      venue,
-    }));
-  }, []);
-
-  const setTournament = useCallback((tournament: string) => {
-    setState((prev) => ({
-      ...prev,
-      tournament,
-    }));
-  }, []);
-
-  const updateInning = useCallback((inning: number, isTop: boolean) => {
-    setState((prev) => ({
-      ...prev,
-      currentInning: inning,
-      isTop,
-      outs: 0,
-      runners: emptyRunners(),
-    }));
-  }, []);
-
-  const addAtBat = useCallback((atBat: AtBat) => {
-    setState((prev) => {
-      const teamKey = atBat.isTop ? 'awayTeam' : 'homeTeam';
-      const targetTeam = prev[teamKey];
-      const updatedTeam: Team = {
-        ...targetTeam,
-        atBats: [...targetTeam.atBats, atBat],
-      };
-
-      let nextState: GameState = {
+  const setAwayTeam = useCallback(
+    (team: Team) => {
+      setState((prev) => ({
         ...prev,
-        [teamKey]: updatedTeam,
-      };
+        awayTeam: normalizeTeam(team),
+      }));
+    },
+    [setState]
+  );
 
-      if (atBat.isOut) {
-        const newOuts = prev.outs + 1;
-        if (newOuts >= 3) {
-          const nextInning = prev.isTop
-            ? prev.currentInning
-            : prev.currentInning + 1;
-          nextState = {
-            ...nextState,
-            outs: 0,
-            runners: emptyRunners(),
-            currentInning: nextInning,
-            isTop: !prev.isTop,
-          };
+  const setGameId = useCallback(
+    (id: string) => {
+      setState((prev) => ({
+        ...prev,
+        id,
+      }));
+    },
+    [setState]
+  );
+
+  const setDate = useCallback(
+    (date: string) => {
+      setState((prev) => ({
+        ...prev,
+        date,
+      }));
+    },
+    [setState]
+  );
+
+  const setVenue = useCallback(
+    (venue: string) => {
+      setState((prev) => ({
+        ...prev,
+        venue,
+      }));
+    },
+    [setState]
+  );
+
+  const setTournament = useCallback(
+    (tournament: string) => {
+      setState((prev) => ({
+        ...prev,
+        tournament,
+      }));
+    },
+    [setState]
+  );
+
+  const updateInning = useCallback(
+    (inning: number, isTop: boolean) => {
+      setState((prev) => ({
+        ...prev,
+        currentInning: inning,
+        isTop,
+        outs: 0,
+        runners: emptyRunners(),
+      }));
+    },
+    [setState]
+  );
+
+  const addAtBat = useCallback(
+    (atBat: AtBat) => {
+      setState((prev) => {
+        const teamKey = atBat.isTop ? 'awayTeam' : 'homeTeam';
+        const targetTeam = prev[teamKey];
+        const updatedTeam: Team = {
+          ...targetTeam,
+          atBats: [...targetTeam.atBats, atBat],
+        };
+
+        let nextState: GameState = {
+          ...prev,
+          [teamKey]: updatedTeam,
+        };
+
+        if (atBat.isOut) {
+          const newOuts = prev.outs + 1;
+          if (newOuts >= 3) {
+            const nextInning = prev.isTop
+              ? prev.currentInning
+              : prev.currentInning + 1;
+            nextState = {
+              ...nextState,
+              outs: 0,
+              runners: emptyRunners(),
+              currentInning: nextInning,
+              isTop: !prev.isTop,
+            };
+          } else {
+            nextState = {
+              ...nextState,
+              outs: newOuts,
+            };
+          }
         } else {
+          const bases = getBaseAdvancement(atBat.result);
           nextState = {
             ...nextState,
-            outs: newOuts,
+            runners: advanceRunners(prev.runners, bases),
           };
         }
-      } else {
-        const bases = getBaseAdvancement(atBat.result);
-        nextState = {
-          ...nextState,
-          runners: advanceRunners(prev.runners, bases),
-        };
-      }
 
-      return nextState;
-    });
-  }, []);
-
-  const updateAtBat = useCallback((updatedAtBat: AtBat) => {
-    setState((prev) => {
-      const updateTeam = (team: Team): Team => ({
-        ...team,
-        atBats: team.atBats.map((ab) =>
-          ab.id === updatedAtBat.id ? updatedAtBat : ab
-        ),
+        return nextState;
       });
+    },
+    [setState]
+  );
 
-      if (prev.homeTeam.atBats.some((ab) => ab.id === updatedAtBat.id)) {
-        return { ...prev, homeTeam: updateTeam(prev.homeTeam) };
-      }
-      if (prev.awayTeam.atBats.some((ab) => ab.id === updatedAtBat.id)) {
-        return { ...prev, awayTeam: updateTeam(prev.awayTeam) };
-      }
-      return prev;
-    });
-  }, []);
+  const updateAtBat = useCallback(
+    (updatedAtBat: AtBat) => {
+      setState((prev) => {
+        const updateTeam = (team: Team): Team => ({
+          ...team,
+          atBats: team.atBats.map((ab) =>
+            ab.id === updatedAtBat.id ? updatedAtBat : ab
+          ),
+        });
 
-  const deleteAtBat = useCallback((atBatId: string) => {
-    setState((prev) => {
-      if (prev.homeTeam.atBats.some((ab) => ab.id === atBatId)) {
-        return {
-          ...prev,
-          homeTeam: {
-            ...prev.homeTeam,
-            atBats: prev.homeTeam.atBats.filter((ab) => ab.id !== atBatId),
-          },
-        };
-      }
-      if (prev.awayTeam.atBats.some((ab) => ab.id === atBatId)) {
-        return {
-          ...prev,
-          awayTeam: {
-            ...prev.awayTeam,
-            atBats: prev.awayTeam.atBats.filter((ab) => ab.id !== atBatId),
-          },
-        };
-      }
-      return prev;
-    });
-  }, []);
+        if (prev.homeTeam.atBats.some((ab) => ab.id === updatedAtBat.id)) {
+          return { ...prev, homeTeam: updateTeam(prev.homeTeam) };
+        }
+        if (prev.awayTeam.atBats.some((ab) => ab.id === updatedAtBat.id)) {
+          return { ...prev, awayTeam: updateTeam(prev.awayTeam) };
+        }
+        return prev;
+      });
+    },
+    [setState]
+  );
 
-  const addRunEvent = useCallback((event: RunEvent) => {
-    setState((prev) => ({
-      ...prev,
-      runEvents: [...prev.runEvents, event],
-    }));
-  }, []);
+  const deleteAtBat = useCallback(
+    (atBatId: string) => {
+      setState((prev) => {
+        if (prev.homeTeam.atBats.some((ab) => ab.id === atBatId)) {
+          return {
+            ...prev,
+            homeTeam: {
+              ...prev.homeTeam,
+              atBats: prev.homeTeam.atBats.filter((ab) => ab.id !== atBatId),
+            },
+          };
+        }
+        if (prev.awayTeam.atBats.some((ab) => ab.id === atBatId)) {
+          return {
+            ...prev,
+            awayTeam: {
+              ...prev.awayTeam,
+              atBats: prev.awayTeam.atBats.filter((ab) => ab.id !== atBatId),
+            },
+          };
+        }
+        return prev;
+      });
+    },
+    [setState]
+  );
 
-  const deleteRunEvent = useCallback((eventId: string) => {
-    setState((prev) => ({
-      ...prev,
-      runEvents: prev.runEvents.filter((event) => event.id !== eventId),
-    }));
-  }, []);
+  const addRunEvent = useCallback(
+    (event: RunEvent) => {
+      setState((prev) => ({
+        ...prev,
+        runEvents: [...prev.runEvents, event],
+      }));
+    },
+    [setState]
+  );
 
-  const addOutEvent = useCallback((event: OutEvent) => {
-    setState((prev) => ({
-      ...prev,
-      outEvents: [...prev.outEvents, event],
-    }));
-  }, []);
+  const deleteRunEvent = useCallback(
+    (eventId: string) => {
+      setState((prev) => ({
+        ...prev,
+        runEvents: prev.runEvents.filter((event) => event.id !== eventId),
+      }));
+    },
+    [setState]
+  );
 
-  const deleteOutEvent = useCallback((eventId: string) => {
-    setState((prev) => ({
-      ...prev,
-      outEvents: prev.outEvents.filter((event) => event.id !== eventId),
-    }));
-  }, []);
+  const addOutEvent = useCallback(
+    (event: OutEvent) => {
+      setState((prev) => ({
+        ...prev,
+        outEvents: [...prev.outEvents, event],
+      }));
+    },
+    [setState]
+  );
+
+  const deleteOutEvent = useCallback(
+    (eventId: string) => {
+      setState((prev) => ({
+        ...prev,
+        outEvents: prev.outEvents.filter((event) => event.id !== eventId),
+      }));
+    },
+    [setState]
+  );
 
   const resetGame = useCallback(() => {
-    setState(buildInitialState());
-  }, []);
+    // 新しい試合を開始する際は、前の試合の undo/redo 履歴も破棄する
+    resetHistory(buildInitialState());
+  }, [resetHistory]);
 
-  const loadGame = useCallback((game: Game) => {
-    setState(buildInitialState(game));
-  }, []);
+  const loadGame = useCallback(
+    (game: Game) => {
+      // 別の試合を読み込む際は、以前の試合の undo/redo 履歴も破棄する
+      resetHistory(buildInitialState(game));
+    },
+    [resetHistory]
+  );
 
   return {
     state,
@@ -341,6 +404,12 @@ export const useGameState = (initialGame?: Game): UseGameStateReturn => {
       updateInning,
       resetGame,
       loadGame,
+    },
+    history: {
+      canUndo,
+      canRedo,
+      undo,
+      redo,
     },
   };
 };

--- a/src/hooks/useUndoRedo.ts
+++ b/src/hooks/useUndoRedo.ts
@@ -9,14 +9,18 @@ interface UndoRedoState<T> {
   future: T[];
 }
 
+// past 履歴の上限。長時間の試合入力でメモリが際限なく増えるのを防ぐ
+const MAX_HISTORY_LENGTH = 50;
+
 /**
  * Return type for the useUndoRedo hook
  */
 export interface UseUndoRedoReturn<T> {
   /** Current state */
   state: T;
-  /** Set new state (adds current to history) */
-  set: (newState: T) => void;
+  /** Set new state (adds current to history). Accepts a value or an updater
+   * function that receives the current present state, like React's setState. */
+  set: (newState: T | ((prevState: T) => T)) => void;
   /** Undo to previous state */
   undo: () => void;
   /** Redo to next state */
@@ -63,12 +67,25 @@ export function useUndoRedo<T>(initialState: T): UseUndoRedoReturn<T> {
     [history.future.length]
   );
 
-  const set = useCallback((newState: T) => {
-    setHistory((prev) => ({
-      past: [...prev.past, prev.present],
-      present: newState,
-      future: [], // Clear future on new change
-    }));
+  const set = useCallback((newStateOrUpdater: T | ((prevState: T) => T)) => {
+    setHistory((prev) => {
+      const newPresent =
+        typeof newStateOrUpdater === 'function'
+          ? (newStateOrUpdater as (prevState: T) => T)(prev.present)
+          : newStateOrUpdater;
+
+      const newPast = [...prev.past, prev.present];
+      // 上限を超えた分は古い履歴から破棄する
+      if (newPast.length > MAX_HISTORY_LENGTH) {
+        newPast.splice(0, newPast.length - MAX_HISTORY_LENGTH);
+      }
+
+      return {
+        past: newPast,
+        present: newPresent,
+        future: [], // Clear future on new change
+      };
+    });
   }, []);
 
   const undo = useCallback(() => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,10 +3,17 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
 
 // jest-axe のマッチャを登録
 expect.extend(toHaveNoViolations);
+
+// CI 環境（特に Node 16/18 の実行ジョブ）はローカルより実行が遅く、
+// Suspense で遅延ロードするコンポーネントを含むテストが既定の
+// 1000ms では間に合わずフレーキーに失敗することがあるため、
+// findBy* / waitFor の既定タイムアウトを緩和する
+configure({ asyncUtilTimeout: 5000 });
 
 // axeの設定（必要に応じてルール緩和をここで定義可能）
 export const axe = configureAxe({});


### PR DESCRIPTION
## 概要
Closes #229

未保存の試合データが確認なしに、あるいは無警告で失われる経路が3つあった。

## 変更内容

### 1. 「新しい試合」の確認ダイアログ
`gameState` の最新スナップショットと直前に保存済みのスナップショットを比較して
`hasUnsavedChanges` を判定し、未保存の変更がある状態で「新しい試合」を選ぶと
確認ダイアログを表示するようにした（`src/MainApp.tsx`）。保存成功・新規試合の
作成・別の試合の読み込み直後は、その時点の内容を新しい基準として記録し直す。

### 2. 下書きの自動保存・復元
`gameState` の変更を1秒デバウンスして `localStorage`（`baseball-score:draft:<uid>`、
ユーザーごとに分離）に下書き保存するようにした。ログイン直後（共有リンク読み込み
時を除く）に前回の下書きが残っていれば復元を提案し、Firestore への保存が成功
すると下書きを破棄する（`src/MainApp.tsx`）。

### 3. `useUndoRedo` の接続
- `useUndoRedo.set` が React の `setState` と同様に更新関数
  `(prev) => next` を受け付けるように拡張し、`past` 履歴に上限（50件）を
  設けてメモリが際限なく増えないようにした（`src/hooks/useUndoRedo.ts`）。
- `useGameState` が内部状態を `useUndoRedo` 経由で管理するように変更し、
  `canUndo` / `canRedo` / `undo` / `redo` を新しい `history` フィールドで
  公開（`src/hooks/useGameState.ts`）。`resetGame` / `loadGame` は
  `useUndoRedo` の `reset()` を使い、試合を切り替えた際に前の試合の履歴が
  残らないようにした。
- `MainApp` の「N回の操作」セクションに「元に戻す」「やり直す」ボタンを追加。

## 受け入れ基準
- [x] 未保存の変更がある状態で「新しい試合」を選ぶと確認ダイアログが出る
- [x] 試合入力中にリロードしても、直前までの入力が復帰できる
- [x] Firestore 保存成功後は下書きが残らない
- [x] 打席の登録・削除・得点イベント追加を元に戻せる
- [x] `useUndoRedo` がプロダクションコードから参照されている

## テスト
- `src/hooks/__tests__/useUndoRedo.test.ts`: 更新関数対応・履歴上限の
  2ケースを追加。
- `src/hooks/__tests__/useGameState.test.ts`: `history.undo`/`redo` で
  `addAtBat` を取り消し・再適用できること、`resetGame`/`loadGame` が
  履歴をクリアすることを追加。
- `src/MainApp.test.tsx`（新規）: 未保存変更なし/ありでの「新しい試合」
  の挙動、確認ダイアログのキャンセル/実行、元に戻す/やり直す、リロード
  相当の再マウント時の下書き復元提案、の5ケース。いずれも修正前のコード
  に対して実行して Red を確認したうえで、修正後 Green を確認済み。
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check` ✅
- `npm test -- --watchAll=false`（27 suites / 163 tests）✅
- `npm run build` ✅

## 確認できなかった検証・既知の制約
- `npm start` によるデスクトップ／モバイル目視確認: このローカル環境では
  `react-scripts start` が既存の `webpack-dev-server` オプション不整合で
  クラッシュするため実行不可（#223 の PR で報告済み、本 PR の変更とは無関係）。
  上記の `MainApp.test.tsx`（実際のダイアログ操作・打席登録・undo/redo・
  localStorage 経由の再マウント）で機能的な回帰確認は行った。
- `node scripts/check-bundle-size.js` はメインバンドルが上限（1024KB）を
  超過して失敗するが、これは `main` ブランチの時点で既に116.5%
  （1193.05KB）と超過しており、本 PR による増加は約5KBのみ。ゲート自体の
  問題は #206 のスコープと判断し、本 PR では対応していない。
- localStorage の下書きは同一ブラウザ内のみで有効な簡易的な復旧手段。
  複数タブでの同時編集や端末をまたいだ復元は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)