### PR TITLE
feat: 打席登録フローの再設計（Select廃止・デフォルト結果除去・次打者可視化）

### DIFF
--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import MainApp from './MainApp';
+
+let mockUuidCounter = 0;
+jest.mock('uuid', () => ({ v4: () => `test-uuid-${mockUuidCounter++}` }));
+
+jest.mock('./contexts/AuthContext', () => ({
+  useAuth: () => ({
+    currentUser: { uid: 'test-user', email: 'test@example.com' },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('./firebase/gameService', () => ({
+  saveGame: jest.fn(),
+  getGameById: jest.fn(),
+  getSharedGameById: jest.fn().mockResolvedValue(null),
+  saveGameAsNew: jest.fn(),
+}));
+
+jest.mock('./firebase/teamService', () => ({
+  getTeamById: jest.fn(),
+  getUserTeams: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('./firebase/analyticsClient', () => ({
+  logAnalyticsEvent: jest.fn(),
+}));
+
+const renderMainApp = () =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MainApp toggleColorMode={jest.fn()} mode="light" />
+    </ThemeProvider>
+  );
+
+const findPlayerRow = async (playerName: string) => {
+  const nameCell = await screen.findByText(playerName);
+  const row = nameCell.closest('tr');
+  if (!row) throw new Error(`row for ${playerName} not found`);
+  return row;
+};
+
+const registerAtBatFor = async (
+  user: ReturnType<typeof userEvent.setup>,
+  playerName: string
+) => {
+  const row = await findPlayerRow(playerName);
+  await user.click(within(row).getByRole('button', { name: '打席登録' }));
+};
+
+describe('MainApp - 打席登録フロー', () => {
+  test('初期状態では打順1番の選手が次打者として表示される', async () => {
+    renderMainApp();
+
+    const row = await findPlayerRow('選手1');
+    expect(within(row).getByText('次打者')).toBeInTheDocument();
+  }, 30000);
+
+  test('打席結果を選ばずに登録することはできない', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await registerAtBatFor(user, '選手1');
+
+    expect(await screen.findByRole('button', { name: '登録' })).toBeDisabled();
+  }, 30000);
+
+  test('打席登録後、次打者の表示とフォーカスが選手2に進む', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await registerAtBatFor(user, '選手1');
+    await screen.findByRole('heading', { name: /打席結果登録: 選手1/ });
+
+    await user.click(screen.getByRole('button', { name: '内野安打' }));
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    // ダイアログが閉じ、選手2が次打者として表示される
+    const nextRow = await findPlayerRow('選手2');
+    await waitFor(() => {
+      expect(within(nextRow).getByText('次打者')).toBeInTheDocument();
+    });
+
+    // 選手2の打席登録ボタンへフォーカスが進む
+    await waitFor(() => {
+      expect(
+        within(nextRow).getByRole('button', { name: '打席登録' })
+      ).toHaveFocus();
+    });
+  }, 30000);
+});

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -1,5 +1,12 @@
 /* istanbul ignore file */
-import React, { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  lazy,
+  Suspense,
+} from 'react';
 import {
   Container,
   AppBar,
@@ -74,6 +81,8 @@ import { useTheme } from '@mui/material/styles';
 import { useGameState } from './hooks/useGameState';
 import { logAnalyticsEvent } from './firebase/analyticsClient';
 import { generateDefaultPlayers } from './utils/defaultPlayers';
+import { getNextBatterPlayerId } from './services/BattingOrder';
+import { registerAtBatButtonId } from './components/PlayerList';
 
 // 遅延ロード - 初期表示に不要なコンポーネント
 const GameList = lazy(() => import('./components/GameList'));
@@ -165,6 +174,9 @@ const MainApp: React.FC<{
   // 現在選択されているチーム
   const currentTeam = tabIndex === 0 ? awayTeam : homeTeam;
 
+  // 打席登録後、次打者の「打席登録」ボタンへフォーカスを進めるための対象選手ID
+  const pendingNextBatterFocusIdRef = useRef<string | null>(null);
+
   // 打席結果の編集関連の状態
   const [editingAtBat, setEditingAtBat] = useState<AtBat | null>(null);
 
@@ -250,6 +262,20 @@ const MainApp: React.FC<{
 
     checkSharedGame();
   }, [loadGame]);
+
+  // 打席登録後、次打者の「打席登録」ボタンへフォーカスを移す
+  useEffect(() => {
+    if (!pendingNextBatterFocusIdRef.current) return;
+
+    const nextBatterId = pendingNextBatterFocusIdRef.current;
+    pendingNextBatterFocusIdRef.current = null;
+
+    // ダイアログが閉じてボタンが再描画されるのを待ってからフォーカスする
+    const frame = requestAnimationFrame(() => {
+      document.getElementById(registerAtBatButtonId(nextBatterId))?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [currentTeam.atBats]);
 
   // ローディング中表示
   if (sharedGameLoading || isLoading) {
@@ -338,6 +364,13 @@ const MainApp: React.FC<{
   const handleAddAtBat = (atBat: AtBat) => {
     gameActions.addAtBat(atBat);
     setSelectedPlayer(null);
+
+    // 登録後に次打者の「打席登録」ボタンへフォーカスを進める
+    const updatedTeam = {
+      ...currentTeam,
+      atBats: [...currentTeam.atBats, atBat],
+    };
+    pendingNextBatterFocusIdRef.current = getNextBatterPlayerId(updatedTeam);
   };
 
   // 打席結果の編集ハンドラー

--- a/src/components/AtBatForm.tsx
+++ b/src/components/AtBatForm.tsx
@@ -10,8 +10,9 @@ import {
   TextField,
   Typography,
   Grid,
-  ListSubheader,
   Stack,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import {
   CheckCircle as CheckCircleIcon,
@@ -22,8 +23,6 @@ import {
 import { HitResult, Player, AtBat } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import { HIT_RESULTS, OUT_RESULTS } from '../services/ScoreCalculator';
-
-const DEFAULT_RESULT: HitResult = 'GO_2B';
 
 // カスタムカラー定義
 const customColors = {
@@ -162,7 +161,8 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   onUpdateAtBat,
   onCancelEdit,
 }) => {
-  const [result, setResult] = useState<HitResult>(DEFAULT_RESULT);
+  // 誤入力を防ぐため、初期状態では結果を未選択（null）にする
+  const [result, setResult] = useState<HitResult | null>(null);
   const [description, setDescription] = useState('');
   const [rbi, setRbi] = useState<number>(0);
   const [successMessage, setSuccessMessage] = useState('');
@@ -171,7 +171,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
   const resetFormFields = useCallback(() => {
-    setResult(DEFAULT_RESULT);
+    setResult(null);
     setDescription('');
     setRbi(0);
   }, []);
@@ -214,6 +214,9 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    // 結果が未選択の場合は登録・更新できない（送信ボタンも disabled にしているが、念のため型ガード）
+    if (!result) return;
 
     if (isEditMode && editingAtBat) {
       if (!onUpdateAtBat) return;
@@ -304,48 +307,73 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
 
       <Box component="form" onSubmit={handleSubmit}>
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
-            <FormControl fullWidth>
-              <InputLabel id="result-label">打席結果</InputLabel>
-              <Select
-                labelId="result-label"
-                value={result}
-                onChange={(e) => setResult(e.target.value as HitResult)}
-                label="打席結果"
-                required
-                aria-required="true"
-                aria-describedby="result-helper-text"
-              >
-                {hitOptions.map((group) => [
-                  <ListSubheader key={group.category}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      {getCategoryIcon(group.category)}
-                      <span>{group.category}</span>
-                    </Box>
-                  </ListSubheader>,
-                  ...group.items.map((hit) => (
-                    <MenuItem key={hit} value={hit}>
-                      <Typography
+          <Grid item xs={12}>
+            <Typography
+              id="result-group-label"
+              variant="subtitle2"
+              gutterBottom
+            >
+              打席結果（必須）
+            </Typography>
+            <Box
+              role="group"
+              aria-labelledby="result-group-label"
+              aria-describedby="result-helper-text"
+            >
+              {hitOptions.map((group) => (
+                <Box key={group.category} sx={{ mb: 1.5 }}>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      mb: 0.5,
+                    }}
+                  >
+                    {getCategoryIcon(group.category)}
+                    {group.category}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={
+                      result && group.items.includes(result) ? result : null
+                    }
+                    exclusive
+                    onChange={(_e, value: HitResult | null) => {
+                      if (value) setResult(value);
+                    }}
+                    aria-label={group.category}
+                    sx={{ flexWrap: 'wrap', rowGap: 0.5, columnGap: 0.5 }}
+                  >
+                    {group.items.map((hit) => (
+                      <ToggleButton
+                        key={hit}
+                        value={hit}
+                        size="small"
                         sx={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          width: '100%',
+                          textTransform: 'none',
+                          minHeight: 40,
+                          borderColor: getResultColor(hit),
                           color: getResultColor(hit),
+                          '&.Mui-selected, &.Mui-selected:hover': {
+                            backgroundColor: getResultColor(hit),
+                            color: '#fff',
+                          },
                         }}
                       >
-                        <span>{hitResultLabels[hit]}</span>
-                        <span style={{ color: 'gray', fontSize: '0.8em' }}>
-                          {hit}
-                        </span>
-                      </Typography>
-                    </MenuItem>
-                  )),
-                ])}
-              </Select>
-              <FormHelperText id="result-helper-text">
-                打席の結果を選択してください
-              </FormHelperText>
-            </FormControl>
+                        {hitResultLabels[hit]}
+                      </ToggleButton>
+                    ))}
+                  </ToggleButtonGroup>
+                </Box>
+              ))}
+            </Box>
+            <FormHelperText id="result-helper-text" error={!result}>
+              {result
+                ? `選択中: ${hitResultLabels[result]}`
+                : '打席の結果をタップして選択してください'}
+            </FormHelperText>
           </Grid>
 
           <Grid item xs={12} sm={6}>
@@ -395,7 +423,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
                   variant="contained"
                   color="primary"
                   fullWidth
-                  disabled={!onUpdateAtBat}
+                  disabled={!onUpdateAtBat || !result}
                 >
                   更新
                 </Button>
@@ -415,6 +443,7 @@ const AtBatForm: React.FC<AtBatFormProps> = ({
                 variant="contained"
                 color="primary"
                 fullWidth
+                disabled={!result}
               >
                 登録
               </Button>

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -16,6 +16,7 @@ import {
   FormControl,
   SelectChangeEvent,
   Box,
+  Chip,
   useTheme,
   useMediaQuery,
 } from '@mui/material';
@@ -25,12 +26,17 @@ import PersonOffIcon from '@mui/icons-material/PersonOff';
 import PersonIcon from '@mui/icons-material/Person';
 import { Player } from '../types';
 
+// 打席登録ボタンの id プレフィックス。次打者へフォーカスを進める際に使う
+export const registerAtBatButtonId = (playerId: string): string =>
+  `register-atbat-${playerId}`;
+
 interface PlayerListProps {
   players: Player[];
   onRegisterAtBat?: (player: Player) => void;
   onToggleStatus?: (playerId: string) => void;
   onEditPlayer?: (playerId: string) => void;
   onUpdatePlayerOrder?: (playerId: string, order: number) => void;
+  nextBatterPlayerId?: string | null;
 }
 
 const PlayerList: React.FC<PlayerListProps> = ({
@@ -39,6 +45,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
   onToggleStatus,
   onEditPlayer,
   onUpdatePlayerOrder,
+  nextBatterPlayerId = null,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -92,96 +99,118 @@ const PlayerList: React.FC<PlayerListProps> = ({
         </TableHead>
         <TableBody>
           {activePlayers.length > 0 ? (
-            activePlayers.map((player) => (
-              <TableRow
-                key={player.id}
-                sx={{
-                  '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.04)' },
-                }}
-              >
-                <TableCell>
-                  {onUpdatePlayerOrder ? (
-                    <FormControl size="small" sx={{ minWidth: 65 }}>
-                      <Select
-                        value={player.order === 0 ? '' : player.order}
-                        onChange={(e: SelectChangeEvent<number>) =>
-                          handleOrderChange(player.id, e)
-                        }
-                        displayEmpty
-                      >
-                        <MenuItem value="">
-                          <em>未設定</em>
-                        </MenuItem>
-                        {orderOptions.map((order) => (
-                          <MenuItem key={order} value={order}>
-                            {order}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  ) : (
-                    player.order || '未設定'
-                  )}
-                </TableCell>
-                <TableCell>{player.number}</TableCell>
-                <TableCell>{player.name}</TableCell>
-                <TableCell>{player.position}</TableCell>
-                <TableCell>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: 0.5,
-                      '& .MuiButton-root': {
-                        minWidth: isMobile ? '36px' : '64px',
-                        padding: isMobile ? '4px 8px' : undefined,
-                      },
-                    }}
-                  >
-                    {onRegisterAtBat && (
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={() => onRegisterAtBat(player)}
-                        color="primary"
-                        startIcon={
-                          isMobile ? (
-                            <AssignmentIcon fontSize="small" />
-                          ) : undefined
-                        }
-                      >
-                        {isMobile ? '打席' : '打席登録'}
-                      </Button>
-                    )}
-                    {onToggleStatus && (
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={() => onToggleStatus(player.id)}
-                        color="secondary"
-                        startIcon={
-                          isMobile ? (
-                            <PersonOffIcon fontSize="small" />
-                          ) : undefined
-                        }
-                      >
-                        {isMobile ? '控え' : '控えに'}
-                      </Button>
-                    )}
-                    {onEditPlayer && (
-                      <Tooltip title="選手情報を編集">
-                        <IconButton
-                          size="small"
-                          onClick={() => onEditPlayer(player.id)}
+            activePlayers.map((player) => {
+              const isNextBatter = player.id === nextBatterPlayerId;
+              return (
+                <TableRow
+                  key={player.id}
+                  selected={isNextBatter}
+                  sx={{
+                    '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.04)' },
+                    ...(isNextBatter && {
+                      backgroundColor: 'action.selected',
+                    }),
+                  }}
+                >
+                  <TableCell>
+                    {onUpdatePlayerOrder ? (
+                      <FormControl size="small" sx={{ minWidth: 65 }}>
+                        <Select
+                          value={player.order === 0 ? '' : player.order}
+                          onChange={(e: SelectChangeEvent<number>) =>
+                            handleOrderChange(player.id, e)
+                          }
+                          displayEmpty
                         >
-                          <EditIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
+                          <MenuItem value="">
+                            <em>未設定</em>
+                          </MenuItem>
+                          {orderOptions.map((order) => (
+                            <MenuItem key={order} value={order}>
+                              {order}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    ) : (
+                      player.order || '未設定'
                     )}
-                  </Box>
-                </TableCell>
-              </TableRow>
-            ))
+                  </TableCell>
+                  <TableCell>{player.number}</TableCell>
+                  <TableCell>
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                    >
+                      {player.name}
+                      {isNextBatter && (
+                        <Chip
+                          label="次打者"
+                          size="small"
+                          color="primary"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell>{player.position}</TableCell>
+                  <TableCell>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 0.5,
+                        '& .MuiButton-root': {
+                          minWidth: isMobile ? '36px' : '64px',
+                          padding: isMobile ? '4px 8px' : undefined,
+                        },
+                      }}
+                    >
+                      {onRegisterAtBat && (
+                        <Button
+                          id={registerAtBatButtonId(player.id)}
+                          variant="outlined"
+                          size="small"
+                          onClick={() => onRegisterAtBat(player)}
+                          color="primary"
+                          startIcon={
+                            isMobile ? (
+                              <AssignmentIcon fontSize="small" />
+                            ) : undefined
+                          }
+                        >
+                          {isMobile ? '打席' : '打席登録'}
+                        </Button>
+                      )}
+                      {onToggleStatus && (
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          onClick={() => onToggleStatus(player.id)}
+                          color="secondary"
+                          startIcon={
+                            isMobile ? (
+                              <PersonOffIcon fontSize="small" />
+                            ) : undefined
+                          }
+                        >
+                          {isMobile ? '控え' : '控えに'}
+                        </Button>
+                      )}
+                      {onEditPlayer && (
+                        <Tooltip title="選手情報を編集">
+                          <IconButton
+                            size="small"
+                            onClick={() => onEditPlayer(player.id)}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              );
+            })
           ) : (
             <TableRow>
               <TableCell colSpan={5} align="center">

--- a/src/components/TeamManager.tsx
+++ b/src/components/TeamManager.tsx
@@ -26,6 +26,7 @@ import { Team, Player, TeamSetting } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import PlayerList from './PlayerList';
 import { getUserTeams, getTeamById } from '../firebase/teamService';
+import { getNextBatterPlayerId } from '../services/BattingOrder';
 
 interface TeamManagerProps {
   team: Team;
@@ -291,6 +292,7 @@ const TeamManager: React.FC<TeamManagerProps> = ({
         onToggleStatus={handleTogglePlayerStatus}
         onEditPlayer={handleEditPlayer}
         onUpdatePlayerOrder={handleUpdatePlayerOrder}
+        nextBatterPlayerId={getNextBatterPlayerId(team)}
       />
 
       {/* 選手追加/編集ダイアログ */}

--- a/src/components/__tests__/AtBatForm.a11y.test.tsx
+++ b/src/components/__tests__/AtBatForm.a11y.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from '../../setupTests';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import AtBatForm from '../AtBatForm';
+import { Player } from '../../types';
 
 // uuid は ESM のため、Jest 上ではモックして回避
 jest.mock('uuid', () => ({ v4: () => 'test-id' }));
@@ -12,11 +14,50 @@ const renderWithTheme = (ui: React.ReactElement) => {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 };
 
+const player: Player = {
+  id: 'player-1',
+  name: '山田',
+  number: '1',
+  position: '投手',
+  isActive: true,
+  order: 1,
+};
+
 describe('AtBatForm accessibility', () => {
   test('has no axe violations (empty state)', async () => {
     const { container } = renderWithTheme(
       <AtBatForm player={null} inning={1} isTop={true} onAddAtBat={() => {}} />
     );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('has no axe violations (結果未選択の打席登録フォーム)', async () => {
+    const { container } = renderWithTheme(
+      <AtBatForm
+        player={player}
+        inning={1}
+        isTop={true}
+        onAddAtBat={() => {}}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('has no axe violations (結果選択後の打席登録フォーム)', async () => {
+    const user = userEvent.setup();
+    const { container, getByRole } = renderWithTheme(
+      <AtBatForm
+        player={player}
+        inning={1}
+        isTop={true}
+        onAddAtBat={() => {}}
+      />
+    );
+
+    await user.click(getByRole('button', { name: '内野安打' }));
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/components/__tests__/AtBatForm.test.tsx
+++ b/src/components/__tests__/AtBatForm.test.tsx
@@ -81,7 +81,7 @@ describe('AtBatForm', () => {
     );
   });
 
-  test('編集対象が外部でクリアされたら入力値を初期化する', async () => {
+  test('編集対象が外部でクリアされたら入力値を初期化し、結果が未選択の間は登録できない', async () => {
     const onAddAtBat = jest.fn();
     const user = userEvent.setup();
     const { rerender } = renderForm({
@@ -104,14 +104,43 @@ describe('AtBatForm', () => {
         />
       </ThemeProvider>
     );
+
+    // 結果が未選択の間は登録できない（誤った既定値での登録を防ぐ）
+    expect(screen.getByRole('button', { name: '登録' })).toBeDisabled();
+    expect(onAddAtBat).not.toHaveBeenCalled();
+
+    // 結果をタップして選択すると登録できるようになる
+    await user.click(screen.getByRole('button', { name: '内野安打' }));
     await user.click(screen.getByRole('button', { name: '登録' }));
 
     expect(onAddAtBat).toHaveBeenCalledWith(
       expect.objectContaining({
-        result: 'GO_2B',
+        result: 'IH',
         description: undefined,
         rbi: 0,
       })
+    );
+  });
+
+  test('打席結果をボタンでタップして選択できる', async () => {
+    const onAddAtBat = jest.fn();
+    const user = userEvent.setup();
+    renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat,
+    });
+
+    expect(screen.getByRole('button', { name: '登録' })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'ホームラン' }));
+    expect(screen.getByRole('button', { name: '登録' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    expect(onAddAtBat).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'HR', isOut: false })
     );
   });
 });

--- a/src/services/BattingOrder.ts
+++ b/src/services/BattingOrder.ts
@@ -1,0 +1,25 @@
+import { Team } from '../types';
+
+/**
+ * 打順に基づき、次に打席へ立つ選手の ID を返す。
+ *
+ * 出場中（isActive）かつ打順が設定されている（order > 0）選手のみを対象とし、
+ * これまでに記録された打席数を打順の人数で割った余りから次打者を求める。
+ * 打順はイニングをまたいで継続するという実際の野球のルールに準拠する。
+ *
+ * @param team 対象チーム（players と atBats を含む）
+ * @returns 次打者の選手ID。打順が設定された出場選手がいない場合は null
+ */
+export function getNextBatterPlayerId(team: Team): string | null {
+  const battingOrder = [...team.players]
+    .filter((player) => player.isActive && player.order > 0)
+    .sort((a, b) => a.order - b.order);
+
+  if (battingOrder.length === 0) {
+    return null;
+  }
+
+  const completedAtBats = team.atBats.length;
+  const nextIndex = completedAtBats % battingOrder.length;
+  return battingOrder[nextIndex].id;
+}

--- a/src/services/__tests__/BattingOrder.test.ts
+++ b/src/services/__tests__/BattingOrder.test.ts
@@ -1,0 +1,106 @@
+import { getNextBatterPlayerId } from '../BattingOrder';
+import { Team, Player, AtBat } from '../../types';
+
+const makePlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: 'p1',
+  name: '選手1',
+  number: '1',
+  position: 'CF',
+  isActive: true,
+  order: 1,
+  ...overrides,
+});
+
+const makeAtBat = (overrides: Partial<AtBat> = {}): AtBat => ({
+  id: 'ab1',
+  playerId: 'p1',
+  inning: 1,
+  isTop: true,
+  result: 'IH',
+  rbi: 0,
+  isOut: false,
+  ...overrides,
+});
+
+const makeTeam = (players: Player[], atBats: AtBat[] = []): Team => ({
+  id: 'team-1',
+  name: 'チーム',
+  players,
+  atBats,
+});
+
+describe('getNextBatterPlayerId', () => {
+  test('打席がまだない場合、打順1番の選手を返す', () => {
+    const team = makeTeam([
+      makePlayer({ id: 'p1', order: 1 }),
+      makePlayer({ id: 'p2', order: 2 }),
+      makePlayer({ id: 'p3', order: 3 }),
+    ]);
+
+    expect(getNextBatterPlayerId(team)).toBe('p1');
+  });
+
+  test('打席数に応じて次の打順の選手を返す', () => {
+    const team = makeTeam(
+      [
+        makePlayer({ id: 'p1', order: 1 }),
+        makePlayer({ id: 'p2', order: 2 }),
+        makePlayer({ id: 'p3', order: 3 }),
+      ],
+      [makeAtBat({ id: 'ab1', playerId: 'p1' })]
+    );
+
+    expect(getNextBatterPlayerId(team)).toBe('p2');
+  });
+
+  test('打順は打者一巡後も継続する', () => {
+    const team = makeTeam(
+      [
+        makePlayer({ id: 'p1', order: 1 }),
+        makePlayer({ id: 'p2', order: 2 }),
+        makePlayer({ id: 'p3', order: 3 }),
+      ],
+      [
+        makeAtBat({ id: 'ab1', playerId: 'p1' }),
+        makeAtBat({ id: 'ab2', playerId: 'p2' }),
+        makeAtBat({ id: 'ab3', playerId: 'p3' }),
+      ]
+    );
+
+    expect(getNextBatterPlayerId(team)).toBe('p1');
+  });
+
+  test('打順が未設定（order: 0）の選手は対象外', () => {
+    const team = makeTeam([
+      makePlayer({ id: 'p1', order: 0 }),
+      makePlayer({ id: 'p2', order: 1 }),
+    ]);
+
+    expect(getNextBatterPlayerId(team)).toBe('p2');
+  });
+
+  test('控え（isActive: false）の選手は対象外', () => {
+    const team = makeTeam([
+      makePlayer({ id: 'p1', order: 1, isActive: false }),
+      makePlayer({ id: 'p2', order: 2, isActive: true }),
+    ]);
+
+    expect(getNextBatterPlayerId(team)).toBe('p2');
+  });
+
+  test('打順が設定された出場選手がいない場合は null を返す', () => {
+    const team = makeTeam([makePlayer({ id: 'p1', order: 0 })]);
+
+    expect(getNextBatterPlayerId(team)).toBeNull();
+  });
+
+  test('打順は数値順ではなく設定順（order の昇順）で解決する', () => {
+    const team = makeTeam([
+      makePlayer({ id: 'p3', order: 3 }),
+      makePlayer({ id: 'p1', order: 1 }),
+      makePlayer({ id: 'p2', order: 2 }),
+    ]);
+
+    expect(getNextBatterPlayerId(team)).toBe('p1');
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,10 +3,17 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
 
 // jest-axe のマッチャを登録
 expect.extend(toHaveNoViolations);
+
+// CI 環境（特に Node 16/18 の実行ジョブ）やローカルでの並列テスト実行時は
+// Suspense で遅延ロードするコンポーネントを含むテストが既定の 1000ms では
+// 間に合わずフレーキーに失敗することがあるため、findBy* / waitFor の
+// 既定タイムアウトを緩和する
+configure({ asyncUtilTimeout: 8000 });
 
 // axeの設定（必要に応じてルール緩和をここで定義可能）
 export const axe = configureAxe({});


### PR DESCRIPTION
## 概要
Closes #230

打席登録は1試合あたり50〜80回発生する最頻操作だが、片手・直射日光下・
数秒しか目を離せない実使用シーンに対して次の3つの問題があった。

## 変更内容

### 1. 25項目の Select をタップ即選択のボタングリッドに置き換え（`AtBatForm.tsx`）
既存の `hitOptions`（ヒット/ゴロアウト/フライアウト/その他アウト/犠打犠飛/その他）
をそのままセクション見出しとして使い、各結果を `ToggleButtonGroup` のボタンとして
配置。色分けは既存の `getResultColor` をそのまま流用。選手を選んでから
「結果をタップ」→「登録をタップ」の2タップで完了する。

### 2. デフォルト結果（`GO_2B`）の除去
`result` のフォーム内状態を `HitResult | null` にし、初期値は未選択とした。
結果が選択されるまで「登録」「更新」ボタンは disabled になり、無言で
誤データ（セカンドゴロ）が登録されることがなくなった。

### 3. 次打者の可視化
- `src/services/BattingOrder.ts`（新規）: `getNextBatterPlayerId(team)` が、
  出場中かつ打順が設定された選手と、これまでの打席数から次打者を算出する
  純粋関数（打順はイニングをまたいで継続）。
- `PlayerList`: 次打者の行に「次打者」チップを表示し、各選手の「打席登録」
  ボタンに安定した id を付与（`registerAtBatButtonId`）。
- `TeamManager`: `team` から次打者を計算して `PlayerList` に渡す。
- `MainApp`: 打席登録後、次に打席へ立つ選手を算出し、ダイアログが閉じて
  一覧が再描画されたタイミングでその選手の「打席登録」ボタンへ
  フォーカスを移す。

### その他
- `setupTests.ts`: Testing Library の `asyncUtilTimeout` を緩和
  （Suspense を含む新しい `MainApp.test.tsx` の統合テストや、並列実行時の
  フレーキーさ対策。#223 の PR で先行して対応した内容と同じ）。

## 受け入れ基準
- [x] 打席結果の登録が、選手を選んでから2タップ以内で完了する
- [x] 結果を選ばずに登録することができない
- [x] 次に打席に立つ選手が画面上で識別できる（「次打者」チップ）
- [x] 打席登録後、次打者にフォーカスが進む
- [x] `AtBatForm` の既存テスト（`AtBatForm.test.tsx`・`AtBatForm.a11y.test.tsx`）
      が新 UI に追従している

## テスト
- `src/services/__tests__/BattingOrder.test.ts`（新規）: 打順の解決・一巡後の
  継続・控え/打順未設定選手の除外などを検証。
- `src/components/__tests__/AtBatForm.test.tsx`: 新しい既定値なし挙動、
  ボタンタップでの選択を検証するテストを追加・更新。
- `src/components/__tests__/AtBatForm.a11y.test.tsx`: 結果未選択／選択後の
  フォームで jest-axe 違反がないことを追加検証。
- `src/MainApp.test.tsx`: 初期表示で打順1番が次打者表示されること、結果
  未選択では登録できないこと、登録後に次打者の表示とフォーカスが選手2に
  進むことを検証。修正前のコードに対して実行し Red を確認したうえで、
  修正後 Green を確認済み。
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check` ✅
- `npm test -- --watchAll=false`（28 suites / 167 tests、連続2回実行して
  安定を確認）✅
- `npm run build` ✅

## 確認できなかった検証・既知の制約
- `npm start` によるデスクトップ／モバイル目視確認: このローカル環境では
  `react-scripts start` が既存の `webpack-dev-server` オプション不整合で
  クラッシュするため実行不可（#223 の PR で報告済み）。本 PR は UI の主要な
  操作導線を変更するため、ユーザー側で Firebase staging 環境
  （`baseball-score-staging`）にデプロイして実機で確認する想定。
- RBI（打点）の入力は今回 Select のままとした（Issue の指摘対象は25項目の
  結果 Select であり、5項目の打点 Select は対象外と判断）。
- 「次打者」はイニングをまたいで打順が継続する前提の派生値（永続状態は
  追加していない）。控え選手への交代や打順の並び替えを試合途中で行うと、
  次の打席登録時点の打順設定で再計算される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)