### PR TITLE
fix: npm start が動作しない問題を解消（webpack-dev-server v5対応）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "baseball-score",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -36,6 +37,7 @@
         "eslint-config-prettier": "^10.1.8",
         "jest-axe": "^11.0.0",
         "jest-junit": "^17.0.0",
+        "patch-package": "^8.0.1",
         "prettier": "^3.9.6"
       }
     },
@@ -5555,6 +5557,13 @@
       "version": "4.2.2",
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "license": "BSD-3-Clause"
@@ -8959,6 +8968,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/firebase": {
       "version": "12.17.1",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.17.1.tgz",
@@ -11715,6 +11734,26 @@
       "version": "0.4.1",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "license": "MIT"
@@ -11737,6 +11776,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -11771,6 +11820,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -12563,6 +12622,79 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/path-exists": {
@@ -16047,6 +16179,16 @@
     "node_modules/thunky": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
-    "ci:local": "npx prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\" && npm run lint && npx tsc --noEmit && npm run test:ci && npm run build"
+    "ci:local": "npx prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\" && npm run lint && npx tsc --noEmit && npm run test:ci && npm run build",
+    "postinstall": "patch-package"
   },
   "eslintConfig": {
     "extends": [
@@ -70,6 +71,7 @@
     "eslint-config-prettier": "^10.1.8",
     "jest-axe": "^11.0.0",
     "jest-junit": "^17.0.0",
+    "patch-package": "^8.0.1",
     "prettier": "^3.9.6"
   },
   "overrides": {

--- a/patches/react-scripts+5.0.1.patch
+++ b/patches/react-scripts+5.0.1.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/react-scripts/config/webpackDevServer.config.js b/node_modules/react-scripts/config/webpackDevServer.config.js
+index 522a81b..44abbd3 100644
+--- a/node_modules/react-scripts/config/webpackDevServer.config.js
++++ b/node_modules/react-scripts/config/webpackDevServer.config.js
+@@ -99,7 +99,12 @@ module.exports = function (proxy, allowedHost) {
+       publicPath: paths.publicUrlOrPath.slice(0, -1),
+     },
+ 
+-    https: getHttpsConfig(),
++    server: (() => {
++      const httpsConfig = getHttpsConfig();
++      if (!httpsConfig) return 'http';
++      if (httpsConfig === true) return 'https';
++      return { type: 'https', options: httpsConfig };
++    })(),
+     host,
+     historyApiFallback: {
+       // Paths with dots should still use the history fallback.
+@@ -109,7 +114,11 @@ module.exports = function (proxy, allowedHost) {
+     },
+     // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
+     proxy,
+-    onBeforeSetupMiddleware(devServer) {
++    setupMiddlewares(middlewares, devServer) {
++      if (!devServer) {
++        throw new Error('webpack-dev-server is not defined');
++      }
++
+       // Keep `evalSourceMapMiddleware`
+       // middlewares before `redirectServedPath` otherwise will not have any effect
+       // This lets us fetch source contents from webpack for the error overlay
+@@ -119,8 +128,7 @@ module.exports = function (proxy, allowedHost) {
+         // This registers user provided middleware for proxy reasons
+         require(paths.proxySetup)(devServer.app);
+       }
+-    },
+-    onAfterSetupMiddleware(devServer) {
++
+       // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
+       devServer.app.use(redirectServedPath(paths.publicUrlOrPath));
+ 
+@@ -130,6 +138,8 @@ module.exports = function (proxy, allowedHost) {
+       // it used the same host and port.
+       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
+       devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
++
++      return middlewares;
+     },
+   };
+ };


### PR DESCRIPTION
## 概要

`npm start` が起動直後にクラッシュし、開発サーバーが使えない不具合を調査・修正した。
（このセッション中、複数のPRでE2E目視確認ができなかった原因もこれ）

## 原因

`package.json` の `overrides` で `webpack-dev-server` を `^5.2.2` に固定している
（4.x系の脆弱性対応のための意図的な上書き、履歴上 dependabot 対応の一環）。
一方 `react-scripts@5.0.1` は `webpack-dev-server@^4.6.0` 向けの設定 API
（`https` オプション、`onBeforeSetupMiddleware` / `onAfterSetupMiddleware` フック）
を使っており、これらは webpack-dev-server 5 で廃止済み。結果として
`npm start` は `Invalid options object` エラーで即クラッシュしていた。

## 対応

`webpack-dev-server` を4系に戻さず（脆弱性対応を維持したまま）、
`patch-package` で `node_modules/react-scripts/config/webpackDevServer.config.js`
を webpack-dev-server 5 の新 API に対応させた。

- `https: getHttpsConfig()` → `server: (...)`（`http` / `https` /
  `{ type: 'https', options }` を返す）
- `onBeforeSetupMiddleware` + `onAfterSetupMiddleware` → 単一の
  `setupMiddlewares(middlewares, devServer)` に統合
- `package.json` に `postinstall: patch-package` を追加し、
  `npm install` / `npm ci` のたびにパッチが再適用されるようにした

## 確認

- `npm start` が正常にコンパイルされ、ブラウザで `http://localhost:PORT`
  にアクセスするとログイン画面が表示されることを確認（Chrome で目視確認）
- `rm -rf node_modules && npm install`（実質的にクリーンインストール）後も
  `postinstall` でパッチが自動再適用されることを確認
- `npm run build`（本番ビルド）は開発サーバー設定に依存しないため無影響
  であることを確認
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test -- --watchAll=false`（29 suites / 181 tests）✅
- `npm run build` ✅

## 影響範囲

開発体験（`npm start`）のみの変更で、本番ビルド・Firestore・セキュリティ設定への
影響はない。`webpack-dev-server` のバージョン自体は変更していないため、
既存の脆弱性対応（#141 / #174 関連）は維持される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)