### PR TITLE
fix: コンポーネント横断の async/状態ライフサイクル修正（TeamStatsList・authService・useUndoRedo・gameService）

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -17,7 +17,7 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import PersonIcon from '@mui/icons-material/Person';
 import { useAuth } from '../contexts/AuthContext';
-import { getAuthErrorMessage } from '../firebase/authService';
+import { getAuthErrorMessage } from '../utils/authErrorMessage';
 
 // タブパネルのProps
 interface TabPanelProps {

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -17,6 +17,7 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import PersonIcon from '@mui/icons-material/Person';
 import { useAuth } from '../contexts/AuthContext';
+import { getAuthErrorMessage } from '../firebase/authService';
 
 // タブパネルのProps
 interface TabPanelProps {
@@ -92,22 +93,22 @@ const Login: React.FC = () => {
       setLoading(true);
       setError(null);
       await loginWithEmailAndPassword(email, password);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Email login failed:', err);
-      let errorMsg = 'ログインに失敗しました。';
-
-      // Firebase Auth のエラーメッセージをより分かりやすく翻訳
-      if (
-        err.code === 'auth/user-not-found' ||
-        err.code === 'auth/wrong-password'
-      ) {
-        errorMsg = 'メールアドレスまたはパスワードが正しくありません';
-      } else if (err.code === 'auth/too-many-requests') {
-        errorMsg =
-          'ログイン試行回数が多すぎます。しばらく時間をおいてから再度お試しください';
-      }
-
-      setError(errorMsg);
+      setError(
+        getAuthErrorMessage(
+          err,
+          {
+            'auth/user-not-found':
+              'メールアドレスまたはパスワードが正しくありません',
+            'auth/wrong-password':
+              'メールアドレスまたはパスワードが正しくありません',
+            'auth/too-many-requests':
+              'ログイン試行回数が多すぎます。しばらく時間をおいてから再度お試しください',
+          },
+          'ログインに失敗しました。'
+        )
+      );
     } finally {
       setLoading(false);
     }
@@ -132,20 +133,21 @@ const Login: React.FC = () => {
       await registerWithEmailAndPassword(email, password, displayName);
       // 登録成功後、自動的にログインタブに切り替え
       setTabValue(0);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Registration failed:', err);
-      let errorMsg = '登録に失敗しました。';
-
-      if (err.code === 'auth/email-already-in-use') {
-        errorMsg = 'このメールアドレスは既に使用されています';
-      } else if (err.code === 'auth/invalid-email') {
-        errorMsg = '有効なメールアドレスを入力してください';
-      } else if (err.code === 'auth/weak-password') {
-        errorMsg =
-          'パスワードが弱すぎます。より強力なパスワードを設定してください';
-      }
-
-      setError(errorMsg);
+      setError(
+        getAuthErrorMessage(
+          err,
+          {
+            'auth/email-already-in-use':
+              'このメールアドレスは既に使用されています',
+            'auth/invalid-email': '有効なメールアドレスを入力してください',
+            'auth/weak-password':
+              'パスワードが弱すぎます。より強力なパスワードを設定してください',
+          },
+          '登録に失敗しました。'
+        )
+      );
     } finally {
       setLoading(false);
     }
@@ -166,17 +168,19 @@ const Login: React.FC = () => {
       setError(
         'パスワードリセットのリンクを送信しました。メールを確認してください'
       );
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Password reset failed:', err);
-      let errorMsg = 'パスワードリセットに失敗しました。';
-
-      if (err.code === 'auth/user-not-found') {
-        errorMsg = 'このメールアドレスに関連するアカウントが見つかりません';
-      } else if (err.code === 'auth/invalid-email') {
-        errorMsg = '有効なメールアドレスを入力してください';
-      }
-
-      setError(errorMsg);
+      setError(
+        getAuthErrorMessage(
+          err,
+          {
+            'auth/user-not-found':
+              'このメールアドレスに関連するアカウントが見つかりません',
+            'auth/invalid-email': '有効なメールアドレスを入力してください',
+          },
+          'パスワードリセットに失敗しました。'
+        )
+      );
     } finally {
       setLoading(false);
     }

--- a/src/components/TeamStatsList.tsx
+++ b/src/components/TeamStatsList.tsx
@@ -27,7 +27,11 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { getAllTeamStats, TeamStats } from '../firebase/statsService';
+import {
+  getAllTeamStats,
+  TeamStats,
+  MIN_QUALIFYING_AT_BATS,
+} from '../firebase/statsService';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -51,55 +55,158 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
+// 打撃成績のキーと表示ラベルを一箇所にまとめ、各表示箇所（チーム/選手 ×
+// モバイル/デスクトップ）で使い回す。値は team.battingStats / player の
+// どちらも同じキーで参照できる（PlayerBattingStats は BattingStats を継承）
+type StatKey =
+  | 'gameCount'
+  | 'atBats'
+  | 'hits'
+  | 'doubles'
+  | 'triples'
+  | 'homeRuns'
+  | 'rbis'
+  | 'walks'
+  | 'strikeouts'
+  | 'battingAvg'
+  | 'obp'
+  | 'slg'
+  | 'ops';
+
+interface StatFieldConfig {
+  label: string;
+  shortLabel?: string;
+  isRate?: boolean;
+}
+
+const STAT_FIELDS: Record<StatKey, StatFieldConfig> = {
+  gameCount: { label: '試合数', shortLabel: '試合' },
+  atBats: { label: '打数' },
+  hits: { label: '安打' },
+  doubles: { label: '二塁打', shortLabel: '2B' },
+  triples: { label: '三塁打', shortLabel: '3B' },
+  homeRuns: { label: '本塁打', shortLabel: 'HR' },
+  rbis: { label: '打点' },
+  walks: { label: '四死球' },
+  strikeouts: { label: '三振' },
+  battingAvg: { label: '打率', isRate: true },
+  obp: { label: '出塁率', isRate: true },
+  slg: { label: '長打率', isRate: true },
+  ops: { label: 'OPS', isRate: true },
+};
+
+// テーブル・カードで並べる順序（各表示箇所は必要なキーだけを部分的に使う）
+// gameCount は BattingStats に含まれず team.battingStats / player どちらでも
+// 別枠で扱うため、ここでは除外した型にする
+type BattingStatKey = Exclude<StatKey, 'gameCount'>;
+
+const DESKTOP_TABLE_ORDER: BattingStatKey[] = [
+  'atBats',
+  'hits',
+  'doubles',
+  'triples',
+  'homeRuns',
+  'rbis',
+  'walks',
+  'strikeouts',
+  'battingAvg',
+  'obp',
+  'slg',
+  'ops',
+];
+
+const TEAM_MOBILE_ORDER: StatKey[] = [
+  'battingAvg',
+  'gameCount',
+  'atBats',
+  'hits',
+  'homeRuns',
+  'rbis',
+  'walks',
+  'strikeouts',
+  'obp',
+  'slg',
+  'ops',
+];
+
+const PLAYER_MOBILE_ORDER: StatKey[] = [
+  'gameCount',
+  'atBats',
+  'hits',
+  'doubles',
+  'triples',
+  'homeRuns',
+  'rbis',
+  'walks',
+  'strikeouts',
+  'obp',
+  'slg',
+  'ops',
+];
+
+// 打率などをフォーマット
+const formatBattingAvg = (value: number): string => {
+  return value.toFixed(3).replace(/^0+/, '');
+};
+
+const formatStatValue = (key: StatKey, value: number): string =>
+  STAT_FIELDS[key].isRate ? formatBattingAvg(value) : String(value);
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return '不明なエラーが発生しました';
+};
+
 const TeamStatsList: React.FC = () => {
   const [teamStats, setTeamStats] = useState<TeamStats[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tabValue, setTabValue] = useState(0);
-  const [selectedTeamIndex, setSelectedTeamIndex] = useState<number | null>(
-    null
-  );
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   // 成績をフェッチ
   useEffect(() => {
+    let cancelled = false;
+
     const fetchTeamStats = async () => {
       try {
         setLoading(true);
         setError(null);
         const stats = await getAllTeamStats();
+        if (cancelled) return;
+
         setTeamStats(stats);
         // 最初のチームが選択された状態にする
         if (stats.length > 0) {
-          setSelectedTeamIndex(0);
+          setSelectedTeamId(stats[0].teamId);
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
+        if (cancelled) return;
         console.error('Error fetching team stats:', err);
-        setError(`成績の取得に失敗しました: ${err.message}`);
+        setError(`成績の取得に失敗しました: ${getErrorMessage(err)}`);
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
 
     fetchTeamStats();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
 
-  const handleTeamSelect = (index: number) => {
-    setSelectedTeamIndex(index);
-  };
-
-  // 打率などをフォーマット
-  const formatBattingAvg = (value: number): string => {
-    return value.toFixed(3).replace(/^0+/, '');
-  };
-
-  // 選手の最低打席数（表示フィルター用）
-  const MIN_PLAYER_AT_BATS = 10;
+  // 選択中のチーム（一覧が変化しても存在しないIDを指し続けない）
+  const selectedTeam =
+    teamStats.find((team) => team.teamId === selectedTeamId) ?? null;
 
   if (loading) {
     return (
@@ -205,39 +312,17 @@ const TeamStatsList: React.FC = () => {
                   <Typography variant="h6" gutterBottom>
                     {stats.teamName}
                   </Typography>
-                  <Typography variant="body2">
-                    打率: {formatBattingAvg(stats.battingStats.battingAvg)}
-                  </Typography>
-                  <Typography variant="body2">
-                    試合数: {stats.gameCount}
-                  </Typography>
-                  <Typography variant="body2">
-                    打数: {stats.battingStats.atBats}
-                  </Typography>
-                  <Typography variant="body2">
-                    安打: {stats.battingStats.hits}
-                  </Typography>
-                  <Typography variant="body2">
-                    本塁打: {stats.battingStats.homeRuns}
-                  </Typography>
-                  <Typography variant="body2">
-                    打点: {stats.battingStats.rbis}
-                  </Typography>
-                  <Typography variant="body2">
-                    四死球: {stats.battingStats.walks}
-                  </Typography>
-                  <Typography variant="body2">
-                    三振: {stats.battingStats.strikeouts}
-                  </Typography>
-                  <Typography variant="body2">
-                    出塁率: {formatBattingAvg(stats.battingStats.obp)}
-                  </Typography>
-                  <Typography variant="body2">
-                    長打率: {formatBattingAvg(stats.battingStats.slg)}
-                  </Typography>
-                  <Typography variant="body2">
-                    OPS: {formatBattingAvg(stats.battingStats.ops)}
-                  </Typography>
+                  {TEAM_MOBILE_ORDER.map((key) => (
+                    <Typography variant="body2" key={key}>
+                      {STAT_FIELDS[key].label}:{' '}
+                      {formatStatValue(
+                        key,
+                        key === 'gameCount'
+                          ? stats.gameCount
+                          : stats.battingStats[key]
+                      )}
+                    </Typography>
+                  ))}
                 </CardContent>
               </Card>
             ))}
@@ -250,18 +335,11 @@ const TeamStatsList: React.FC = () => {
                 <TableRow>
                   <TableCell>チーム名</TableCell>
                   <TableCell align="center">試合数</TableCell>
-                  <TableCell align="center">打数</TableCell>
-                  <TableCell align="center">安打</TableCell>
-                  <TableCell align="center">二塁打</TableCell>
-                  <TableCell align="center">三塁打</TableCell>
-                  <TableCell align="center">本塁打</TableCell>
-                  <TableCell align="center">打点</TableCell>
-                  <TableCell align="center">四死球</TableCell>
-                  <TableCell align="center">三振</TableCell>
-                  <TableCell align="center">打率</TableCell>
-                  <TableCell align="center">出塁率</TableCell>
-                  <TableCell align="center">長打率</TableCell>
-                  <TableCell align="center">OPS</TableCell>
+                  {DESKTOP_TABLE_ORDER.map((key) => (
+                    <TableCell align="center" key={key}>
+                      {STAT_FIELDS[key].label}
+                    </TableCell>
+                  ))}
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -271,42 +349,11 @@ const TeamStatsList: React.FC = () => {
                       {stats.teamName}
                     </TableCell>
                     <TableCell align="center">{stats.gameCount}</TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.atBats}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.hits}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.doubles}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.triples}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.homeRuns}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.rbis}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.walks}
-                    </TableCell>
-                    <TableCell align="center">
-                      {stats.battingStats.strikeouts}
-                    </TableCell>
-                    <TableCell align="center">
-                      {formatBattingAvg(stats.battingStats.battingAvg)}
-                    </TableCell>
-                    <TableCell align="center">
-                      {formatBattingAvg(stats.battingStats.obp)}
-                    </TableCell>
-                    <TableCell align="center">
-                      {formatBattingAvg(stats.battingStats.slg)}
-                    </TableCell>
-                    <TableCell align="center">
-                      {formatBattingAvg(stats.battingStats.ops)}
-                    </TableCell>
+                    {DESKTOP_TABLE_ORDER.map((key) => (
+                      <TableCell align="center" key={key}>
+                        {formatStatValue(key, stats.battingStats[key])}
+                      </TableCell>
+                    ))}
                   </TableRow>
                 ))}
               </TableBody>
@@ -322,11 +369,13 @@ const TeamStatsList: React.FC = () => {
             チームを選択
           </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-            {teamStats.map((team, index) => (
+            {teamStats.map((team) => (
               <Button
                 key={team.teamId}
-                variant={selectedTeamIndex === index ? 'contained' : 'outlined'}
-                onClick={() => handleTeamSelect(index)}
+                variant={
+                  selectedTeamId === team.teamId ? 'contained' : 'outlined'
+                }
+                onClick={() => setSelectedTeamId(team.teamId)}
                 sx={{ mb: 1 }}
               >
                 {team.teamName}
@@ -335,14 +384,16 @@ const TeamStatsList: React.FC = () => {
           </Box>
         </Box>
 
-        {selectedTeamIndex !== null && (
+        {selectedTeam && (
           <>
             <Typography
               variant="h6"
               sx={{ mt: 3, mb: 2, display: 'flex', alignItems: 'center' }}
             >
-              {teamStats[selectedTeamIndex].teamName}の選手成績
-              <Tooltip title="規定打席（10打席以上）に到達した選手を上位表示しています。">
+              {selectedTeam.teamName}の選手成績
+              <Tooltip
+                title={`規定打数（${MIN_QUALIFYING_AT_BATS}打数以上）に到達した選手を上位表示しています。`}
+              >
                 <IconButton size="small" sx={{ ml: 1 }}>
                   <InfoOutlinedIcon fontSize="small" />
                 </IconButton>
@@ -352,10 +403,10 @@ const TeamStatsList: React.FC = () => {
             {isMobile ? (
               // モバイル向け表示 - アコーディオン形式
               <Box>
-                {teamStats[selectedTeamIndex].playerStats.length === 0 ? (
+                {selectedTeam.playerStats.length === 0 ? (
                   <Alert severity="info">選手の打撃成績はまだありません</Alert>
                 ) : (
-                  teamStats[selectedTeamIndex].playerStats.map((player) => (
+                  selectedTeam.playerStats.map((player) => (
                     <Accordion key={player.playerId} sx={{ mb: 1 }}>
                       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                         <Box
@@ -385,42 +436,12 @@ const TeamStatsList: React.FC = () => {
                             gap: 1,
                           }}
                         >
-                          <Typography variant="body2">
-                            試合数: {player.gameCount}
-                          </Typography>
-                          <Typography variant="body2">
-                            打数: {player.atBats}
-                          </Typography>
-                          <Typography variant="body2">
-                            安打: {player.hits}
-                          </Typography>
-                          <Typography variant="body2">
-                            二塁打: {player.doubles}
-                          </Typography>
-                          <Typography variant="body2">
-                            三塁打: {player.triples}
-                          </Typography>
-                          <Typography variant="body2">
-                            本塁打: {player.homeRuns}
-                          </Typography>
-                          <Typography variant="body2">
-                            打点: {player.rbis}
-                          </Typography>
-                          <Typography variant="body2">
-                            四死球: {player.walks}
-                          </Typography>
-                          <Typography variant="body2">
-                            三振: {player.strikeouts}
-                          </Typography>
-                          <Typography variant="body2">
-                            出塁率: {formatBattingAvg(player.obp)}
-                          </Typography>
-                          <Typography variant="body2">
-                            長打率: {formatBattingAvg(player.slg)}
-                          </Typography>
-                          <Typography variant="body2">
-                            OPS: {formatBattingAvg(player.ops)}
-                          </Typography>
+                          {PLAYER_MOBILE_ORDER.map((key) => (
+                            <Typography variant="body2" key={key}>
+                              {STAT_FIELDS[key].label}:{' '}
+                              {formatStatValue(key, player[key])}
+                            </Typography>
+                          ))}
                         </Box>
                       </AccordionDetails>
                     </Accordion>
@@ -438,34 +459,31 @@ const TeamStatsList: React.FC = () => {
                         名前
                       </TableCell>
                       <TableCell align="center">試合</TableCell>
-                      <TableCell align="center">打数</TableCell>
-                      <TableCell align="center">安打</TableCell>
-                      <TableCell align="center">2B</TableCell>
-                      <TableCell align="center">3B</TableCell>
-                      <TableCell align="center">HR</TableCell>
-                      <TableCell align="center">打点</TableCell>
-                      <TableCell align="center">四死球</TableCell>
-                      <TableCell align="center">三振</TableCell>
-                      <TableCell align="center">打率</TableCell>
-                      <TableCell align="center">出塁率</TableCell>
-                      <TableCell align="center">長打率</TableCell>
-                      <TableCell align="center">OPS</TableCell>
+                      {DESKTOP_TABLE_ORDER.map((key) => (
+                        <TableCell align="center" key={key}>
+                          {STAT_FIELDS[key].shortLabel ??
+                            STAT_FIELDS[key].label}
+                        </TableCell>
+                      ))}
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {teamStats[selectedTeamIndex].playerStats.length === 0 ? (
+                    {selectedTeam.playerStats.length === 0 ? (
                       <TableRow>
-                        <TableCell colSpan={15} align="center">
+                        <TableCell
+                          colSpan={3 + DESKTOP_TABLE_ORDER.length}
+                          align="center"
+                        >
                           選手の打撃成績はまだありません
                         </TableCell>
                       </TableRow>
                     ) : (
-                      teamStats[selectedTeamIndex].playerStats.map((player) => (
+                      selectedTeam.playerStats.map((player) => (
                         <TableRow
                           key={player.playerId}
                           sx={{
                             backgroundColor:
-                              player.atBats >= MIN_PLAYER_AT_BATS
+                              player.atBats >= MIN_QUALIFYING_AT_BATS
                                 ? 'rgba(232, 244, 253, 0.3)'
                                 : 'inherit',
                           }}
@@ -477,30 +495,19 @@ const TeamStatsList: React.FC = () => {
                           <TableCell align="center">
                             {player.gameCount}
                           </TableCell>
-                          <TableCell align="center">{player.atBats}</TableCell>
-                          <TableCell align="center">{player.hits}</TableCell>
-                          <TableCell align="center">{player.doubles}</TableCell>
-                          <TableCell align="center">{player.triples}</TableCell>
-                          <TableCell align="center">
-                            {player.homeRuns}
-                          </TableCell>
-                          <TableCell align="center">{player.rbis}</TableCell>
-                          <TableCell align="center">{player.walks}</TableCell>
-                          <TableCell align="center">
-                            {player.strikeouts}
-                          </TableCell>
-                          <TableCell align="center" sx={{ fontWeight: 'bold' }}>
-                            {formatBattingAvg(player.battingAvg)}
-                          </TableCell>
-                          <TableCell align="center">
-                            {formatBattingAvg(player.obp)}
-                          </TableCell>
-                          <TableCell align="center">
-                            {formatBattingAvg(player.slg)}
-                          </TableCell>
-                          <TableCell align="center">
-                            {formatBattingAvg(player.ops)}
-                          </TableCell>
+                          {DESKTOP_TABLE_ORDER.map((key) => (
+                            <TableCell
+                              align="center"
+                              key={key}
+                              sx={
+                                key === 'battingAvg'
+                                  ? { fontWeight: 'bold' }
+                                  : undefined
+                              }
+                            >
+                              {formatStatValue(key, player[key])}
+                            </TableCell>
+                          ))}
                         </TableRow>
                       ))
                     )}

--- a/src/components/__tests__/TeamStatsList.test.tsx
+++ b/src/components/__tests__/TeamStatsList.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import TeamStatsList from '../TeamStatsList';
 import { getAllTeamStats, TeamStats } from '../../firebase/statsService';
 
 jest.mock('../../firebase/statsService', () => ({
   getAllTeamStats: jest.fn(),
+  MIN_QUALIFYING_AT_BATS: 10,
 }));
 
 const mockedGetAllTeamStats = getAllTeamStats as jest.MockedFunction<
@@ -53,4 +55,64 @@ describe('TeamStatsList', () => {
     expect(await screen.findByText('全勝チーム')).toBeInTheDocument();
     expect(screen.getByText('1.000')).toBeInTheDocument();
   });
+
+  test('Error インスタンスでない例外でも意味のあるメッセージを表示する', async () => {
+    mockedGetAllTeamStats.mockRejectedValue('network down');
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <TeamStatsList />
+      </ThemeProvider>
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('成績の取得に失敗しました');
+    expect(alert).not.toHaveTextContent('undefined');
+  });
+
+  test('選手一覧で規定打数以上の選手にツールチップの数値が反映される', async () => {
+    const teamWithPlayers: TeamStats = {
+      ...allWins,
+      playerStats: [
+        {
+          playerId: 'p1',
+          playerName: '選手1',
+          playerNumber: '1',
+          playerPosition: 'CF',
+          gameCount: 1,
+          atBats: 12,
+          hits: 4,
+          singles: 4,
+          doubles: 0,
+          triples: 0,
+          homeRuns: 0,
+          walks: 0,
+          sacrificeFlies: 0,
+          strikeouts: 0,
+          rbis: 0,
+          battingAvg: 0.333,
+          obp: 0.333,
+          slg: 0.333,
+          ops: 0.666,
+        },
+      ],
+    };
+    mockedGetAllTeamStats.mockResolvedValue([teamWithPlayers]);
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <TeamStatsList />
+      </ThemeProvider>
+    );
+
+    const user = userEvent.setup();
+    await screen.findByText('全勝チーム');
+    await user.click(screen.getByRole('tab', { name: '個人成績' }));
+
+    expect(
+      await screen.findByLabelText(
+        '規定打数（10打数以上）に到達した選手を上位表示しています。'
+      )
+    ).toBeInTheDocument();
+  }, 15000);
 });

--- a/src/firebase/__tests__/authService.test.ts
+++ b/src/firebase/__tests__/authService.test.ts
@@ -1,0 +1,87 @@
+import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
+import {
+  registerWithEmailAndPassword,
+  getAuthErrorMessage,
+} from '../authService';
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({})),
+  GoogleAuthProvider: jest.fn(),
+  signInWithPopup: jest.fn(),
+  signOut: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+  updateProfile: jest.fn(),
+}));
+
+jest.mock('../config', () => ({ app: {} }));
+
+const mockedCreateUser = createUserWithEmailAndPassword as jest.Mock;
+const mockedUpdateProfile = updateProfile as jest.Mock;
+
+describe('registerWithEmailAndPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('updateProfile 後に reload して最新のユーザー情報を返す', async () => {
+    const reload = jest.fn().mockResolvedValue(undefined);
+    const user = { uid: 'u1', displayName: null, reload };
+    mockedCreateUser.mockResolvedValue({ user });
+    mockedUpdateProfile.mockResolvedValue(undefined);
+
+    const result = await registerWithEmailAndPassword(
+      'a@example.com',
+      'password123',
+      '山田太郎'
+    );
+
+    expect(mockedUpdateProfile).toHaveBeenCalledWith(user, {
+      displayName: '山田太郎',
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(result).toBe(user);
+  });
+
+  test('表示名が空の場合は updateProfile も reload も呼ばない', async () => {
+    const reload = jest.fn();
+    const user = { uid: 'u1', displayName: null, reload };
+    mockedCreateUser.mockResolvedValue({ user });
+
+    await registerWithEmailAndPassword('a@example.com', 'password123', '');
+
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('getAuthErrorMessage', () => {
+  test('既知のエラーコードに対応するメッセージを返す', () => {
+    const message = getAuthErrorMessage(
+      { code: 'auth/user-not-found' },
+      { 'auth/user-not-found': 'アカウントが見つかりません' },
+      'デフォルトメッセージ'
+    );
+    expect(message).toBe('アカウントが見つかりません');
+  });
+
+  test('未知のエラーコードにはフォールバックを返す', () => {
+    const message = getAuthErrorMessage(
+      { code: 'auth/unknown-error' },
+      { 'auth/user-not-found': 'アカウントが見つかりません' },
+      'デフォルトメッセージ'
+    );
+    expect(message).toBe('デフォルトメッセージ');
+  });
+
+  test('code を持たない例外（Error インスタンスでない場合も含む）はフォールバックを返す', () => {
+    expect(
+      getAuthErrorMessage('network down', {}, 'デフォルトメッセージ')
+    ).toBe('デフォルトメッセージ');
+    expect(getAuthErrorMessage(null, {}, 'デフォルトメッセージ')).toBe(
+      'デフォルトメッセージ'
+    );
+  });
+});

--- a/src/firebase/__tests__/gameService.test.ts
+++ b/src/firebase/__tests__/gameService.test.ts
@@ -1,7 +1,12 @@
-import { getDoc, updateDoc, addDoc } from 'firebase/firestore';
+import { getDoc, updateDoc, addDoc, getDocs, limit } from 'firebase/firestore';
 import { Game } from '../../types';
 import { getCurrentUser } from '../authService';
-import { saveGame, getSharedGameById } from '../gameService';
+import {
+  saveGame,
+  getSharedGameById,
+  getGameById,
+  getAllGames,
+} from '../gameService';
 
 jest.mock('firebase/firestore', () => ({
   collection: jest.fn(),
@@ -11,6 +16,7 @@ jest.mock('firebase/firestore', () => ({
   getDoc: jest.fn(),
   query: jest.fn(),
   orderBy: jest.fn(),
+  limit: jest.fn((n: number) => `LIMIT_${n}`),
   serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
   deleteDoc: jest.fn(),
   where: jest.fn(),
@@ -24,6 +30,8 @@ jest.mock('../authService', () => ({ getCurrentUser: jest.fn() }));
 const mockedGetDoc = getDoc as jest.Mock;
 const mockedUpdateDoc = updateDoc as jest.Mock;
 const mockedAddDoc = addDoc as jest.Mock;
+const mockedGetDocs = getDocs as jest.Mock;
+const mockedLimit = limit as jest.Mock;
 const mockedGetCurrentUser = getCurrentUser as jest.Mock;
 
 const makeGame = (overrides: Partial<Game> = {}): Game =>
@@ -52,8 +60,10 @@ describe('saveGame (update path)', () => {
       data: () => ({ userId: 'someone-else' }),
     });
 
+    // getGameById は「存在しない」と「他人のデータ」を区別せず null を返すため、
+    // どちらの場合も同じ「データが見つかりません」で失敗する（統一された契約）
     await expect(saveGame(makeGame())).rejects.toThrow(
-      'このデータにアクセスする権限がありません'
+      'データが見つかりません'
     );
     expect(mockedUpdateDoc).not.toHaveBeenCalled();
   });
@@ -139,5 +149,62 @@ describe('getSharedGameById', () => {
     await expect(getSharedGameById('game-1')).rejects.toThrow(
       'この試合データは公開されていません'
     );
+  });
+});
+
+describe('getGameById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetCurrentUser.mockReturnValue({
+      uid: 'user-1',
+      email: 'me@example.com',
+    });
+  });
+
+  it('returns null (not throw) when the document does not exist', async () => {
+    mockedGetDoc.mockResolvedValue({ exists: () => false });
+
+    await expect(getGameById('missing')).resolves.toBeNull();
+  });
+
+  it('returns null (not throw) when the document belongs to another user', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({ userId: 'someone-else' }),
+    });
+
+    // 「存在しない」場合と同じ null を返し、他ユーザーへドキュメントの
+    // 存在有無を区別して伝えない
+    await expect(getGameById('game-1')).resolves.toBeNull();
+  });
+
+  it('returns the game when it belongs to the current user', async () => {
+    mockedGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: 'game-1',
+      data: () => ({ userId: 'user-1', date: '2026-08-17' }),
+    });
+
+    const game = await getGameById('game-1');
+    expect(game?.id).toBe('game-1');
+    expect(game?.date).toBe('2026-08-17');
+  });
+});
+
+describe('getAllGames', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetCurrentUser.mockReturnValue({
+      uid: 'user-1',
+      email: 'me@example.com',
+    });
+    mockedGetDocs.mockResolvedValue({ docs: [] });
+  });
+
+  it('caps the query with limit() to avoid an unbounded fetch', async () => {
+    await getAllGames();
+
+    expect(mockedLimit).toHaveBeenCalledWith(expect.any(Number));
   });
 });

--- a/src/firebase/authService.ts
+++ b/src/firebase/authService.ts
@@ -11,6 +11,9 @@ import {
   updateProfile,
 } from 'firebase/auth';
 import { app } from './config';
+// getAuthErrorMessage は firebase/auth に依存しない純粋な文言変換ロジックのため
+// 別モジュールに切り出してある。呼び出し元の互換性のためここで再エクスポートする。
+import { getAuthErrorMessage } from '../utils/authErrorMessage';
 
 // 認証インスタンスを取得
 const auth = getAuth(app);
@@ -22,24 +25,7 @@ const logAndRethrow = (context: string, error: unknown): never => {
   throw error;
 };
 
-// Firebase Auth のエラーコードを画面表示用の日本語メッセージへ変換する
-// 呼び出し側は文脈ごとに異なるメッセージ（コード→文言）とフォールバックを渡す
-export const getAuthErrorMessage = (
-  error: unknown,
-  messages: Partial<Record<string, string>>,
-  fallback: string
-): string => {
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'string'
-  ) {
-    const code = (error as { code: string }).code;
-    return messages[code] ?? fallback;
-  }
-  return fallback;
-};
+export { getAuthErrorMessage };
 
 // Googleでサインイン
 export const signInWithGoogle = async (): Promise<User> => {

--- a/src/firebase/authService.ts
+++ b/src/firebase/authService.ts
@@ -16,14 +16,38 @@ import { app } from './config';
 const auth = getAuth(app);
 const googleProvider = new GoogleAuthProvider();
 
+// エラーをログに記録したうえで再送出する（各関数の catch を単純化するための共通処理）
+const logAndRethrow = (context: string, error: unknown): never => {
+  console.error(context, error);
+  throw error;
+};
+
+// Firebase Auth のエラーコードを画面表示用の日本語メッセージへ変換する
+// 呼び出し側は文脈ごとに異なるメッセージ（コード→文言）とフォールバックを渡す
+export const getAuthErrorMessage = (
+  error: unknown,
+  messages: Partial<Record<string, string>>,
+  fallback: string
+): string => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  ) {
+    const code = (error as { code: string }).code;
+    return messages[code] ?? fallback;
+  }
+  return fallback;
+};
+
 // Googleでサインイン
-export const signInWithGoogle = async () => {
+export const signInWithGoogle = async (): Promise<User> => {
   try {
     const result = await signInWithPopup(auth, googleProvider);
     return result.user;
   } catch (error) {
-    console.error('Google sign in error:', error);
-    throw error;
+    return logAndRethrow('Google sign in error:', error);
   }
 };
 
@@ -32,7 +56,7 @@ export const registerWithEmailAndPassword = async (
   email: string,
   password: string,
   displayName: string
-) => {
+): Promise<User> => {
   try {
     const result = await createUserWithEmailAndPassword(auth, email, password);
     // ユーザー表示名を設定
@@ -40,11 +64,14 @@ export const registerWithEmailAndPassword = async (
       await updateProfile(result.user, {
         displayName: displayName,
       });
+      // updateProfile 後は onAuthStateChanged が再fire されず、
+      // auth.currentUser / 呼び出し元が受け取る user が displayName: null の
+      // ままになるため、明示的に最新情報を再取得する
+      await result.user.reload();
     }
     return result.user;
   } catch (error) {
-    console.error('Email registration error:', error);
-    throw error;
+    return logAndRethrow('Email registration error:', error);
   }
 };
 
@@ -61,28 +88,25 @@ export const loginWithEmailAndPassword = async (
     );
     return result.user;
   } catch (error) {
-    console.error('Email login error:', error);
-    throw error;
+    return logAndRethrow('Email login error:', error);
   }
 };
 
 // パスワードリセットメールを送信
-export const sendPasswordReset = async (email: string) => {
+export const sendPasswordReset = async (email: string): Promise<void> => {
   try {
     await sendPasswordResetEmail(auth, email);
   } catch (error) {
-    console.error('Password reset error:', error);
-    throw error;
+    logAndRethrow('Password reset error:', error);
   }
 };
 
 // サインアウト
-export const signOut = async () => {
+export const signOut = async (): Promise<void> => {
   try {
     await firebaseSignOut(auth);
   } catch (error) {
-    console.error('Sign out error:', error);
-    throw error;
+    logAndRethrow('Sign out error:', error);
   }
 };
 

--- a/src/firebase/gameService.ts
+++ b/src/firebase/gameService.ts
@@ -6,6 +6,7 @@ import {
   getDoc,
   query,
   orderBy,
+  limit,
   serverTimestamp,
   deleteDoc,
   where,
@@ -17,6 +18,12 @@ import { getCurrentUser } from './authService';
 
 const GAMES_COLLECTION = 'games';
 
+// Firestoreのドキュメントサイズ制限（1MB）に対する安全マージンを見た保存許容サイズ
+const MAX_GAME_DOCUMENT_SIZE_BYTES = 1_000_000;
+
+// getAllGames で一度に取得する試合数の上限（無制限クエリを避ける）
+const MAX_GAMES_PER_PAGE = 200;
+
 // 所有権検証付きで既存の試合データを取得（不存在・他人のデータはエラー）
 const requireOwnedGame = async (gameId: string): Promise<Game> => {
   const game = await getGameById(gameId);
@@ -24,6 +31,41 @@ const requireOwnedGame = async (gameId: string): Promise<Game> => {
     throw new Error('データが見つかりません');
   }
   return game;
+};
+
+// saveGame / saveGameAsNew で共通の保存用ペイロード生成
+// （クローン・所有者情報付与・タイムスタンプ付与・サイズチェックをまとめる）
+const buildGameToSave = (
+  game: Game,
+  user: { uid: string; email: string | null },
+  { resetId }: { resetId: boolean }
+): Record<string, unknown> => {
+  // 保存前にデータを整形（循環参照を避けるため、JSONに変換してから再度パースする）
+  const gameClone = JSON.parse(JSON.stringify(game));
+
+  if (resetId) {
+    delete gameClone.id;
+  }
+
+  const gameToSave = {
+    ...gameClone,
+    userId: user.uid, // ユーザーIDを追加
+    userEmail: user.email, // ユーザーのメールアドレスを追加
+    isPublic: game.isPublic ?? false, // 公開状態を追加
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  };
+
+  const gameDataSize = new Blob([JSON.stringify(gameToSave)]).size;
+  console.log(`Game data size: ${gameDataSize} bytes`);
+
+  if (gameDataSize > MAX_GAME_DOCUMENT_SIZE_BYTES) {
+    throw new Error(
+      `データサイズが大きすぎます (${Math.round(gameDataSize / 1024)} KB)。1MB以下にしてください。`
+    );
+  }
+
+  return gameToSave;
 };
 
 // 試合データを保存
@@ -34,29 +76,7 @@ export const saveGame = async (game: Game): Promise<string> => {
       throw new Error('ログインが必要です');
     }
 
-    // 保存前にデータを整形（循環参照を避けるため、JSONに変換してから再度パースする）
-    const gameClone = JSON.parse(JSON.stringify(game));
-
-    // タイムスタンプを追加
-    const gameToSave = {
-      ...gameClone,
-      userId: user.uid, // ユーザーIDを追加
-      userEmail: user.email, // ユーザーのメールアドレスを追加
-      isPublic: game.isPublic ?? false, // 公開状態を追加
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    };
-
-    // データサイズをチェック
-    const gameDataSize = new Blob([JSON.stringify(gameToSave)]).size;
-    console.log(`Game data size: ${gameDataSize} bytes`);
-
-    // Firestoreのドキュメントサイズ制限は1MB
-    if (gameDataSize > 1000000) {
-      throw new Error(
-        `データサイズが大きすぎます (${Math.round(gameDataSize / 1024)} KB)。1MB以下にしてください。`
-      );
-    }
+    const gameToSave = buildGameToSave(game, user, { resetId: false });
 
     let docRef;
 
@@ -93,32 +113,7 @@ export const saveGameAsNew = async (game: Game): Promise<string> => {
       throw new Error('ログインが必要です');
     }
 
-    // 保存前にデータを整形（循環参照を避けるため、JSONに変換してから再度パースする）
-    const gameClone = JSON.parse(JSON.stringify(game));
-
-    // IDをリセットして新しいゲームとして保存
-    delete gameClone.id;
-
-    // タイムスタンプを追加
-    const gameToSave = {
-      ...gameClone,
-      userId: user.uid, // ユーザーIDを追加
-      userEmail: user.email, // ユーザーのメールアドレスを追加
-      isPublic: game.isPublic ?? false, // 公開状態を追加
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    };
-
-    // データサイズをチェック
-    const gameDataSize = new Blob([JSON.stringify(gameToSave)]).size;
-    console.log(`Game data size: ${gameDataSize} bytes`);
-
-    // Firestoreのドキュメントサイズ制限は1MB
-    if (gameDataSize > 1000000) {
-      throw new Error(
-        `データサイズが大きすぎます (${Math.round(gameDataSize / 1024)} KB)。1MB以下にしてください。`
-      );
-    }
+    const gameToSave = buildGameToSave(game, user, { resetId: true });
 
     // 常に新しいドキュメントを作成
     const docRef = await addDoc(collection(db, GAMES_COLLECTION), gameToSave);
@@ -139,10 +134,12 @@ export const getAllGames = async (): Promise<Game[]> => {
     }
 
     // ユーザーIDでフィルタリングしたクエリを作成
+    // 無制限クエリを避けるため、最新 MAX_GAMES_PER_PAGE 件までに制限する
     const q = query(
       collection(db, GAMES_COLLECTION),
       where('userId', '==', user.uid),
-      orderBy('date', 'desc')
+      orderBy('date', 'desc'),
+      limit(MAX_GAMES_PER_PAGE)
     );
 
     const querySnapshot = await getDocs(q);
@@ -158,24 +155,27 @@ export const getAllGames = async (): Promise<Game[]> => {
 };
 
 // 特定の試合データを取得
+// 契約: ドキュメントが存在しない場合と、存在するが自分のデータでない場合の
+// どちらも null を返す（他ユーザーへドキュメントの存在有無を漏らさないため
+// 区別しない）。それ以外のエラー（ネットワーク等）は throw する
 export const getGameById = async (gameId: string): Promise<Game | null> => {
   try {
     const docRef = doc(db, GAMES_COLLECTION, gameId);
     const docSnap = await getDoc(docRef);
 
-    if (docSnap.exists()) {
-      const data = docSnap.data() as Game;
-
-      // 自分のデータかチェック
-      const user = getCurrentUser();
-      if (!user || data.userId !== user.uid) {
-        throw new Error('このデータにアクセスする権限がありません');
-      }
-
-      return { ...data, id: docSnap.id };
-    } else {
+    if (!docSnap.exists()) {
       return null;
     }
+
+    const data = docSnap.data() as Game;
+
+    // 自分のデータかチェック
+    const user = getCurrentUser();
+    if (!user || data.userId !== user.uid) {
+      return null;
+    }
+
+    return { ...data, id: docSnap.id };
   } catch (error) {
     console.error('Error getting game:', error);
     throw error;

--- a/src/firebase/statsService.ts
+++ b/src/firebase/statsService.ts
@@ -30,6 +30,10 @@ export interface PlayerBattingStats extends BattingStats {
 // ゲームコレクションの定数
 const GAMES_COLLECTION = 'games';
 
+// 選手成績を上位表示する際の規定打数（この値未満は下位に回す）
+// TeamStatsList の表示（背景ハイライト・ツールチップ）と共有する
+export const MIN_QUALIFYING_AT_BATS = 10;
+
 // チームごとの通算成績を取得
 export const getAllTeamStats = async (): Promise<TeamStats[]> => {
   try {
@@ -231,10 +235,9 @@ const aggregatePlayerBattingStats = (teamStats: TeamStats, team: Team) => {
 
   // プレイヤー成績を打率の降順でソート
   teamStats.playerStats.sort((a, b) => {
-    // 打席数が一定数以上ある選手を優先
-    const minAtBats = 10;
-    const aHasMinAtBats = a.atBats >= minAtBats;
-    const bHasMinAtBats = b.atBats >= minAtBats;
+    // 打数が規定数以上ある選手を優先
+    const aHasMinAtBats = a.atBats >= MIN_QUALIFYING_AT_BATS;
+    const bHasMinAtBats = b.atBats >= MIN_QUALIFYING_AT_BATS;
 
     if (aHasMinAtBats && !bHasMinAtBats) return -1;
     if (!aHasMinAtBats && bHasMinAtBats) return 1;

--- a/src/hooks/useUndoRedo.ts
+++ b/src/hooks/useUndoRedo.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 
 /**
  * Interface for the undo/redo state structure
@@ -61,11 +61,9 @@ export function useUndoRedo<T>(initialState: T): UseUndoRedoReturn<T> {
     future: [],
   });
 
-  const canUndo = useMemo(() => history.past.length > 0, [history.past.length]);
-  const canRedo = useMemo(
-    () => history.future.length > 0,
-    [history.future.length]
-  );
+  // 単純な真偽比較なので useMemo による最適化は不要（計算コストがほぼゼロ）
+  const canUndo = history.past.length > 0;
+  const canRedo = history.future.length > 0;
 
   const set = useCallback((newStateOrUpdater: T | ((prevState: T) => T)) => {
     setHistory((prev) => {

--- a/src/utils/__tests__/authErrorMessage.test.ts
+++ b/src/utils/__tests__/authErrorMessage.test.ts
@@ -1,0 +1,30 @@
+import { getAuthErrorMessage } from '../authErrorMessage';
+
+describe('getAuthErrorMessage', () => {
+  test('既知のエラーコードに対応するメッセージを返す', () => {
+    const message = getAuthErrorMessage(
+      { code: 'auth/user-not-found' },
+      { 'auth/user-not-found': 'アカウントが見つかりません' },
+      'デフォルトメッセージ'
+    );
+    expect(message).toBe('アカウントが見つかりません');
+  });
+
+  test('未知のエラーコードにはフォールバックを返す', () => {
+    const message = getAuthErrorMessage(
+      { code: 'auth/unknown-error' },
+      { 'auth/user-not-found': 'アカウントが見つかりません' },
+      'デフォルトメッセージ'
+    );
+    expect(message).toBe('デフォルトメッセージ');
+  });
+
+  test('code を持たない例外（Error インスタンスでない場合も含む）はフォールバックを返す', () => {
+    expect(
+      getAuthErrorMessage('network down', {}, 'デフォルトメッセージ')
+    ).toBe('デフォルトメッセージ');
+    expect(getAuthErrorMessage(null, {}, 'デフォルトメッセージ')).toBe(
+      'デフォルトメッセージ'
+    );
+  });
+});

--- a/src/utils/authErrorMessage.ts
+++ b/src/utils/authErrorMessage.ts
@@ -1,0 +1,25 @@
+// Firebase Auth のエラーコードを画面表示用の日本語メッセージへ変換する
+// 呼び出し側は文脈ごとに異なるメッセージ（コード→文言）とフォールバックを渡す
+//
+// このモジュールは意図的に firebase/auth や ./firebase/authService に依存しない。
+// 依存すると、単に文言変換をしたいだけの呼び出し元（例: Login.tsx）まで
+// Firebase Auth SDK の実初期化（getAuth(app)）を import グラフに引き込んでしまい、
+// Firebase の環境変数が設定されていないテスト環境（CI 等）で
+// `FirebaseError: Firebase: Error (auth/invalid-api-key)` によりテストスイートが
+// 読み込み時点で失敗する原因になる。
+export const getAuthErrorMessage = (
+  error: unknown,
+  messages: Partial<Record<string, string>>,
+  fallback: string
+): string => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  ) {
+    const code = (error as { code: string }).code;
+    return messages[code] ?? fallback;
+  }
+  return fallback;
+};


### PR DESCRIPTION
## 概要
Closes #201

## 変更内容

### TeamStatsList.tsx
- 取得 effect に `cancelled` フラグを追加し、unmount 後に `getAllTeamStats()` が解決しても setState しないようにした
- `catch (err: any)` → `catch (err: unknown)` + 型ガードに変更し、Error でない例外でも「...: undefined」と表示されないようにした
- 選択中チームを配列インデックスではなく `teamId` で追跡し、一覧の内容が変わってもインデックスがずれて範囲外参照にならないようにした
- チーム/選手 × モバイル/デスクトップの4箇所にハードコードされていたフィールドラベル一覧を `STAT_FIELDS` 設定 + コンテキストごとの順序配列にまとめた（表示内容・順序は変更なし）
- `MIN_QUALIFYING_AT_BATS` を `statsService` からエクスポートし、ソート条件と UI（背景ハイライト・ツールチップ）の両方で共有。ツールチップの「打席」表記を、実際に比較している「打数」に合わせて修正

### authService.ts
- `updateProfile` 後に `result.user.reload()` を追加し、表示名の更新が即座に反映されるようにした
- `logAndRethrow` ヘルパを追加し、各関数の catch → console.error → throw の重複を解消
- 全エクスポート関数の戻り値型を `Promise<T>` に統一
- `getAuthErrorMessage(error, messages, fallback)` をエクスポート。`Login.tsx` の3箇所でほぼ同じだった `err.code === '...'` の分岐をこの共通ヘルパ呼び出しに置き換えた

### useUndoRedo.ts
- `canUndo` / `canRedo` の `useMemo` を削除（単純な真偽比較で最適化不要）

### gameService.ts
- `saveGame` / `saveGameAsNew` で重複していたクローン・所有者情報付与・タイムスタンプ付与・サイズチェックを `buildGameToSave` に共通化
- マジックナンバー `1000000` を `MAX_GAME_DOCUMENT_SIZE_BYTES` に定数化
- `getGameById` の契約を統一: 「存在しない」場合と「存在するが自分のデータでない」場合のどちらも `null` を返すようにした（他ユーザーにドキュメントの存在有無を示唆するエラーメッセージの違いをなくした）
- `getAllGames()` に `limit(MAX_GAMES_PER_PAGE)` を追加し、無制限クエリを避けた

## 受け入れ基準
- [x] unmount 後の setState がスキップされる
- [x] undo 履歴に上限が設定される（#229 で先行対応済み。本 PR では `useMemo` の過剰最適化を解消）
- [x] displayName 更新が UI に即時反映される
- [x] getAllGames に limit が付く

## テスト
- `src/components/__tests__/TeamStatsList.test.tsx`: 非 Error 例外のメッセージ、選手一覧のツールチップ文言（規定打数）を検証するテストを追加
- `src/firebase/__tests__/authService.test.ts`（新規）: `registerWithEmailAndPassword` の `reload()` 呼び出し、`getAuthErrorMessage` のコード変換・フォールバックを検証
- `src/firebase/__tests__/gameService.test.ts`: `getGameById` の統一された null 契約、`getAllGames` の `limit()` 呼び出しを検証するテストを追加。既存の「他人のデータへの更新拒否」テストは新しい統一メッセージ（「データが見つかりません」）に合わせて更新
- 該当する変更ファイル一式に対して `npm run lint` ✅ / `npx tsc --noEmit` ✅ / `npx prettier --check` ✅
- `npm test -- --watchAll=false`: 変更した5スイート（46 tests）は個別実行で安定してパス ✅。全30スイートの一括実行はこのローカル環境がマシン負荷高（load average 6〜9 / 8コア、他ユーザーとの共有機材）のため `MainApp.test.tsx` がタイムアウトでフレーキーになることがあったが、本 PR の変更ファイルとは無関係（変更前から存在する重い Suspense 統合テストの実行時間の問題。#207 のスコープに近い）
- `npm run build` ✅

## 確認できなかった検証
- `npm start` によるデスクトップ／モバイル目視確認: 今回の変更は UI の見た目・操作導線を変えていないため（表示内容・順序は現状維持）、目視確認は省略し自動テストで検証した

🤖 Generated with [Claude Code](https://claude.com/claude-code)