### PR TITLE
fix: .codex エージェント設定の安全性・機能性修正

### DIFF
--- a/.codex/agents/docs-researcher.toml
+++ b/.codex/agents/docs-researcher.toml
@@ -1,0 +1,19 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+# This agent's whole job is checking claims against primary sources, so it
+# needs a way to reach them. Without this it was read-only with no network
+# tool at all, and every "verify" instruction below was a no-op.
+web_search = "live"
+
+developer_instructions = """
+Verify claims against primary documentation before they land.
+Cite the exact docs, config files, or release notes that support each claim.
+Do not invent undocumented behavior.
+
+If a source cannot be fetched (network error, paywall, dead link, no search
+result), do not guess or fall back to prior training knowledge as if it were
+verified. State plainly that the claim is UNVERIFIED and say what you tried
+and why it failed, so the parent can decide whether to retry, seek another
+source, or proceed without confirmation.
+"""

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,0 +1,16 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Stay in exploration mode.
+Trace real execution paths, cite exact files and symbols, and avoid proposing edits unless the parent asks for them.
+Prefer targeted reads and searches over broad scans.
+
+Your sandbox is read-only, so you cannot make edits regardless of what is
+asked. If the parent's request implies an edit (e.g. "fix this", "add a
+test"), do not attempt it and do not silently limit yourself to a
+description of the problem either: propose the change as an explicit diff
+(before/after or unified diff) for the parent to apply, and say clearly
+that you did not — and could not — apply it yourself.
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,20 @@
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+# Set explicitly rather than relying on the baseline default: this agent
+# often needs to run tests inside its read-only sandbox (e.g. `npm test`),
+# and approval_policy = "never" silently auto-denies every one of those
+# instead of asking. "on-request" lets the parent approve individual runs.
+approval_policy = "on-request"
+
+developer_instructions = """
+Review like an owner.
+Prioritize, in order: correctness, behavioral regressions, security risks,
+concurrency/race conditions, performance regressions, and missing tests.
+Lead with concrete findings and avoid style-only commentary unless it hides
+a real defect.
+
+For every finding, anchor it to the exact file and line number, and label
+its severity (critical / high / medium / low). A finding without a
+file:line and a severity is not actionable — don't report it that way.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,102 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Super Skills - Codex baseline
+#
+# This file is intentionally lean.
+# Additional MCP servers and higher-risk capabilities should be enabled by
+# profile or generated config later, not added to the default baseline.
+#
+# Baseline is conservative on purpose: an unattended run (no --profile flag)
+# must never get unattended writes or a live web connection. Anything more
+# permissive requires explicitly passing --profile yolo (or another
+# escalation profile below).
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+web_search = "cached"
+
+[features]
+multi_agent = true
+
+# Lean MCP baseline only. Every stdio server below is version-pinned so a
+# session never silently picks up whatever the current npm dist-tag
+# resolves to. Bump these deliberately (and re-review) rather than tracking
+# @latest.
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github@2025.4.8"]
+# GITHUB_PERSONAL_ACCESS_TOKEN must already be exported in the host shell;
+# this only passes it through to the subprocess, it never stores a value
+# here.
+env_vars = ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@4.0.3"]
+
+[mcp_servers.memory]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-memory@2026.7.4"]
+
+[mcp_servers.sequential-thinking]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking@2026.7.4"]
+
+# exa and playwright are NOT part of the lean baseline:
+# - exa was an unauthenticated remote MCP endpoint with no version pin.
+# - playwright used --extension, which attaches to the user's *real*
+#   browser profile (live cookies/login state) — unsafe to expose under a
+#   "never approve" policy.
+# Both are disabled by default via `enabled = false` (the documented
+# activation flag) rather than deleted, so they stay discoverable. Flip
+# `enabled = true` deliberately in a local/session override — do not turn
+# this on in the shared baseline. If your Codex build supports per-profile
+# mcp_servers overrides, prefer scoping the override to a dedicated
+# research/browser profile instead of enabling these globally; verify that
+# syntax against your installed version before relying on it.
+[mcp_servers.exa]
+enabled = false
+url = "https://mcp.exa.ai/mcp"
+# Set EXA_API_KEY in the host shell before enabling; never hardcode the key.
+bearer_token_env_var = "EXA_API_KEY"
+
+[mcp_servers.playwright]
+enabled = false
+command = "npx"
+args = ["-y", "@playwright/mcp@0.0.79"]
+# No --extension: an isolated browser context only. Do not add --extension
+# back to a server that runs under approval_policy = "never".
+
+# Safety-oriented profiles.
+[profiles.strict]
+approval_policy = "on-request"
+sandbox_mode = "read-only"
+web_search = "cached"
+
+# Explicit, opt-in escalation. This is now the ONLY place unattended writes
+# and live web search are enabled — baseline no longer matches this.
+[profiles.yolo]
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+web_search = "live"
+
+[agents]
+max_threads = 6
+max_depth = 1
+# Convention (not currently enforced by the schema): every agent listed
+# below is expected to run with sandbox_mode = "read-only" in its own
+# agents/*.toml. Keep that explicit in each file rather than relying on
+# this comment — see agents/explorer.toml, agents/reviewer.toml,
+# agents/docs-researcher.toml.
+
+[agents.explorer]
+description = "Read-only codebase exploration for evidence gathering before changes."
+config_file = "agents/explorer.toml"
+
+[agents.reviewer]
+description = "Change review focused on correctness, regressions, security, and missing tests."
+config_file = "agents/reviewer.toml"
+
+[agents.docs_researcher]
+description = "Documentation specialist for primary-source API, SDK, and release-note verification."
+config_file = "agents/docs-researcher.toml"

--- a/scripts/check-codex-model-consistency.js
+++ b/scripts/check-codex-model-consistency.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * .codex/agents/*.toml の model スラッグ整合性チェック
+ *
+ * 各エージェント設定ファイルの `model = "..."` が独立して重複定義されており、
+ * 更新時に1箇所だけ変更されて食い違う（例: gpt-5.4 のまま他だけ上がる）のを防ぐ。
+ * TOML パーサを追加せず、行単位の正規表現で `model = "..."` を抽出する
+ * （このスクリプトの用途にはそれで十分）。
+ *
+ * 使用例:
+ *   node scripts/check-codex-model-consistency.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const AGENTS_DIR = path.join(__dirname, '../.codex/agents');
+const MODEL_LINE_PATTERN = /^\s*model\s*=\s*"([^"]+)"/m;
+
+// 1ファイル分の内容から model スラッグを抽出する。見つからない場合は null
+function extractModel(fileContents) {
+  const match = fileContents.match(MODEL_LINE_PATTERN);
+  return match ? match[1] : null;
+}
+
+// agents ディレクトリ内の .toml ファイルそれぞれの model スラッグを集計する
+function collectAgentModels(agentsDir) {
+  const files = fs
+    .readdirSync(agentsDir)
+    .filter((file) => file.endsWith('.toml'))
+    .sort();
+
+  return files.map((file) => {
+    const contents = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+    return { file, model: extractModel(contents) };
+  });
+}
+
+// 収集結果を検証し、問題点のメッセージ配列を返す（空配列なら OK）
+function validateAgentModels(entries) {
+  const problems = [];
+
+  entries.forEach(({ file, model }) => {
+    if (!model) {
+      problems.push(`${file}: no "model = ..." line found`);
+    }
+  });
+
+  const distinctModels = [
+    ...new Set(entries.map((e) => e.model).filter(Boolean)),
+  ];
+  if (distinctModels.length > 1) {
+    const detail = entries
+      .filter((e) => e.model)
+      .map((e) => `${e.file}=${e.model}`)
+      .join(', ');
+    problems.push(`Inconsistent model slugs across agents: ${detail}`);
+  }
+
+  return problems;
+}
+
+function main() {
+  if (!fs.existsSync(AGENTS_DIR)) {
+    console.error(`❌ Agents directory not found: ${AGENTS_DIR}`);
+    process.exit(1);
+  }
+
+  const entries = collectAgentModels(AGENTS_DIR);
+  if (entries.length === 0) {
+    console.error(`❌ No .toml files found in ${AGENTS_DIR}`);
+    process.exit(1);
+  }
+
+  const problems = validateAgentModels(entries);
+
+  console.log('');
+  console.log('🤖 Codex agent model consistency');
+  console.log('═══════════════════════════════════════');
+  entries.forEach(({ file, model }) => {
+    console.log(`  - ${file}: ${model ?? '(missing)'}`);
+  });
+  console.log('═══════════════════════════════════════');
+  console.log('');
+
+  if (problems.length > 0) {
+    console.error('❌ Codex agent model consistency check failed');
+    console.error('');
+    problems.forEach((p) => console.error(`  - ${p}`));
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log('✅ All agent model slugs are consistent');
+  console.log('');
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { extractModel, collectAgentModels, validateAgentModels };

--- a/src/utils/__tests__/checkCodexModelConsistency.test.js
+++ b/src/utils/__tests__/checkCodexModelConsistency.test.js
@@ -1,0 +1,44 @@
+const {
+  extractModel,
+  validateAgentModels,
+} = require('../../../scripts/check-codex-model-consistency');
+
+describe('check-codex-model-consistency', () => {
+  describe('extractModel', () => {
+    it('extracts the model slug from a model = "..." line', () => {
+      const toml = 'model = "gpt-5.4"\nmodel_reasoning_effort = "high"\n';
+      expect(extractModel(toml)).toBe('gpt-5.4');
+    });
+
+    it('returns null when there is no model line', () => {
+      expect(extractModel('sandbox_mode = "read-only"\n')).toBeNull();
+    });
+  });
+
+  describe('validateAgentModels', () => {
+    it('reports no problems when all models match', () => {
+      const entries = [
+        { file: 'a.toml', model: 'gpt-5.4' },
+        { file: 'b.toml', model: 'gpt-5.4' },
+      ];
+      expect(validateAgentModels(entries)).toEqual([]);
+    });
+
+    it('reports a problem when models diverge across files', () => {
+      const entries = [
+        { file: 'a.toml', model: 'gpt-5.4' },
+        { file: 'b.toml', model: 'gpt-5.3' },
+      ];
+      const problems = validateAgentModels(entries);
+      expect(problems).toHaveLength(1);
+      expect(problems[0]).toContain('a.toml=gpt-5.4');
+      expect(problems[0]).toContain('b.toml=gpt-5.3');
+    });
+
+    it('reports a problem when a file has no model line at all', () => {
+      const entries = [{ file: 'a.toml', model: null }];
+      const problems = validateAgentModels(entries);
+      expect(problems).toEqual(['a.toml: no "model = ..." line found']);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Closes #208

`.codex/config.toml` と `.codex/agents/*.toml` はディスク上には存在していたが
git 未追跡だった（`.codex/AGENTS.md` のみ追跡されており、後に root
`AGENTS.md` へ置き換えられ削除済み）。本 PR で初めて version control に
追加し、issue の指摘事項を修正した。

## 変更内容

### .codex/config.toml
- baseline の `approval_policy` を `"never"` → `"on-request"` に変更
  （`web_search` も `"live"` → `"cached"` に）。baseline が
  `[profiles.yolo]` と完全に同一だったため、`--profile` 未指定の実行が
  既に無人書き込み + ライブネットワークになっており、yolo が
  「明示的エスカレーション」として機能していなかった
- 全 stdio MCP サーバ（server-github・context7-mcp・server-memory・
  server-sequential-thinking・@playwright/mcp）を、現在 npm に公開されて
  いるバージョンに pin（`@latest` や無指定を廃止）
- `mcp_servers.github` に `env_vars = ["GITHUB_PERSONAL_ACCESS_TOKEN"]`
  を追加し、ホスト側の既存環境変数を素通しできるようにした（ファイルには
  トークン値を一切保存しない）
- `exa`（無認証のリモートエンドポイント）と `playwright`
  （`--extension` でユーザーの実ブラウザ・cookie に接続）を baseline
  では `enabled = false` にした。`exa` は `bearer_token_env_var =
  "EXA_API_KEY"` で認証を配線し、`playwright` は再度有効化する際も
  `--extension` を使わない（分離ブラウザのみ）ようにした
- `[agents]` に、各 `agents/*.toml` が `sandbox_mode = "read-only"` で
  動く想定であることをコメントで明記（スキーマ上は agents レベルの
  既定値強制はできないため、各ファイル側の明示設定は維持）

### .codex/agents/docs-researcher.toml（bug: high）
- `web_search = "live"` を追加。一次資料の検証が使命なのにネットワーク
  手段が一切なく、「一次資料と照合せよ」という指示が実行不能だった
- 取得できない場合のフォールバックを追記：未検証（UNVERIFIED）と明示し、
  何を試して何故失敗したかを述べる

### .codex/agents/reviewer.toml（bug: medium）
- `approval_policy = "on-request"` を明示的に設定（baseline の値に
  依存させない）。read-only サンドボックス内でテストを実行することが
  あり、`"never"` だと全て自動拒否されていた
- 優先リストに concurrency/race condition・performance regression を追加
- 成果物は file:line と severity のアンカリングを必須にした

### .codex/agents/explorer.toml
- 編集を暗示する依頼への振る舞いを明記：read-only サンドボックスのため
  編集はできないので、明示的な diff を提案する（黙って説明だけに留めない）

### scripts/check-codex-model-consistency.js（新規）
- 各 `agents/*.toml` の `model = "..."` を抽出・比較し、欠落や不一致を
  分かりやすいメッセージで検出する。TOML パーサ依存を避けて正規表現で
  抽出し、`scripts/apply-production-csp.js` / `scripts/check-bundle-size.js`
  と同じ `require.main` ガード + 単体テスト可能な export のパターンに
  合わせた

### 実装上の注記
- 取得した config-schema.json の範囲では `ConfigProfile` に
  `mcp_servers` フィールドが存在せず、プロファイル単位で MCP サーバを
  上書きする公式な構文を確認できなかった。未検証の構文を書いて
  「動いているはず」と主張するリスクを避け、代わりにスキーマ上
  文書化されている `enabled` フラグで `exa` / `playwright` を
  opt-in にした。プロファイル単位の上書きが実際にサポートされているかは、
  導入している Codex のバージョンで確認してから利用してほしい

## 受け入れ基準
- [x] baseline が保守的に、yolo が明示的な escalation になる
- [x] MCP サーバが pin され、ブラウザ/exa が（`enabled = false` による）
      隔離される
- [x] docs-researcher がドキュメント取得可能になる

## テスト
- `python3 -c "import tomllib; ..."` で `config.toml` と3つの
  `agents/*.toml` が有効な TOML としてパースできることを確認
- `node scripts/check-codex-model-consistency.js` を実行し、3ファイルの
  `model` が一致していることを確認
- `src/utils/__tests__/checkCodexModelConsistency.test.js`（新規、5ケース）:
  抽出・一致検証・欠落検出・不一致検出を検証
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check`（変更した .js/.test.js ファイル）✅
- `npm test -- --watchAll=false`（30 suites / 186 tests）✅
- `npm run build` ✅

## 確認できなかった検証
- 実際に Codex CLI を起動して baseline / yolo / strict プロファイルの
  挙動や、`env_vars` によるトークン受け渡し、`enabled = false` の
  MCP サーバ非活性化が意図通りに機能するかは、この環境に Codex CLI が
  ないため未確認。TOML としての妥当性とスキーマに記載のフィールド名の
  一致は確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)