### PR TITLE
fix: コメントアウト残骸による空 UI 要素の除去

### DIFF
--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -260,3 +260,25 @@ describe('MainApp - 打席結果編集ダイアログ', () => {
     expect(title).not.toHaveTextContent('不明な選手');
   }, 30000);
 });
+
+describe('MainApp - コメントアウト残骸の除去', () => {
+  // デスクトップ用の試合日ボタンは <Hidden smDown> 配下にあり、MUI の Hidden は
+  // window.matchMedia に依存するため jsdom では常に非表示（そもそも DOM に
+  // 現れない）になり、この環境では自動テストで検証できない。修正内容
+  // （モバイル版と同じ gameState.date を表示する）は目視・コードレビューで
+  // 確認する。保存ダイアログ側（Hidden に依存しない）は下記でテストする。
+
+  test('保存ダイアログに日付と対戦カードが表示される（空行ではない）', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await user.click(screen.getByRole('button', { name: '試合データを保存' }));
+
+    const dialog = await screen.findByRole('dialog');
+    const expectedDate = new Date().toLocaleDateString('ja-JP');
+    expect(
+      within(dialog).getByText(`日付: ${expectedDate}`)
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText(/対戦: .+ vs .+/)).toBeInTheDocument();
+  }, 15000);
+});

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -246,12 +246,10 @@ const MainApp: React.FC<{
       const sharedGameId = urlParams.get('gameId');
 
       if (sharedGameId) {
-        console.log('Found gameId in URL:', sharedGameId);
         try {
           setSharedGameLoading(true);
           const sharedGame = await getSharedGameById(sharedGameId);
           if (sharedGame) {
-            console.log('Successfully loaded shared game:', sharedGameId);
             pendingBaselineResetRef.current = true;
             loadGame(sharedGame);
             setIsSharedMode(true);
@@ -604,8 +602,6 @@ const MainApp: React.FC<{
     if (showTeamStats) {
       setShowTeamStats(false);
     }
-    // チーム選択ダイアログを表示せず、直接新しい試合画面に遷移
-    // showTeamSelectionDialog();
   };
 
   // 新しい試合を作成（未保存の変更がある場合は確認ダイアログを挟む）
@@ -838,16 +834,8 @@ const MainApp: React.FC<{
 
       // ホームチームかアウェイチームのどちらを更新するか
       if (teamSelectionMode === 'home') {
-        // setGame((prevGame) => ({
-        //   ...prevGame,
-        //   homeTeam: gameTeam,
-        // }));
         gameActions.setHomeTeam(gameTeam);
       } else {
-        // setGame((prevGame) => ({
-        //   ...prevGame,
-        //   awayTeam: gameTeam,
-        // }));
         gameActions.setAwayTeam(gameTeam);
       }
 
@@ -1061,7 +1049,7 @@ const MainApp: React.FC<{
                       aria-describedby="game-date-text"
                     >
                       <span id="game-date-text">
-                        {/* {new Date(game.date).toLocaleDateString('ja-JP')} */}
+                        {new Date(gameState.date).toLocaleDateString('ja-JP')}
                       </span>
                     </Button>
                   </Hidden>
@@ -1073,7 +1061,7 @@ const MainApp: React.FC<{
                     sx={{ mr: isMobile ? 0.5 : 1 }}
                     aria-label="試合データを保存"
                   >
-                    {isMobile ? '保存' : '保存'}
+                    保存
                   </Button>
 
                   <Button
@@ -1114,14 +1102,14 @@ const MainApp: React.FC<{
                 onClick={handleOpenHelpDialog}
                 aria-label="help"
                 title="ヘルプ"
-                size={isMobile ? 'medium' : 'medium'}
+                size="medium"
                 sx={{
                   mr: isMobile ? 0.5 : 0,
                   minWidth: isMobile ? '44px' : undefined,
                   minHeight: isMobile ? '44px' : undefined,
                 }}
               >
-                <HelpIcon fontSize={isMobile ? 'medium' : 'medium'} />
+                <HelpIcon fontSize="medium" />
               </IconButton>
 
               <Suspense fallback={null}>
@@ -1572,14 +1560,16 @@ const MainApp: React.FC<{
           <Typography>現在の試合データを保存しますか？</Typography>
           <Box sx={{ mt: 2 }}>
             <Typography variant="body2">
-              {/* 日付: {new Date(game.date).toLocaleDateString('ja-JP')} */}
+              日付: {new Date(gameState.date).toLocaleDateString('ja-JP')}
             </Typography>
-            {/* {game.tournament && (
-              <Typography variant="body2">大会名: {game.tournament}</Typography>
+            {gameState.tournament && (
+              <Typography variant="body2">
+                大会名: {gameState.tournament}
+              </Typography>
             )}
-            {game.venue && (
-              <Typography variant="body2">場所: {game.venue}</Typography>
-            )} */}
+            {gameState.venue && (
+              <Typography variant="body2">場所: {gameState.venue}</Typography>
+            )}
             <Typography variant="body2">
               対戦: {awayTeam.name} vs {homeTeam.name}
             </Typography>


### PR DESCRIPTION
## 概要
Closes #231

## 変更内容

- **AppBar の空ボタン**: デスクトップ用の試合日ボタン（`<Hidden smDown>`
  配下）の中身がコメントアウトされたままで、空の `<span>` を描画していた。
  モバイル専用の日付ボタンと同じく `gameState.date` を表示するよう復元した
- **保存ダイアログの空行**: 日付・大会名・場所がコメントアウトされ、
  対戦カードしか表示されていなかった。`gameState` から3項目とも復元した
  （大会名・場所は元の実装通り値がある場合のみ表示）
- その他の残骸を除去:
  - `setGame((prevGame) => ...)` の死んだコメントブロック2箇所
    （直後に実行される `gameActions.setHomeTeam` / `setAwayTeam` の
    残骸コメント）
  - 存在しない関数への参照 `// showTeamSelectionDialog();`
  - 両分岐が同値の三項演算子3箇所（`isMobile ? '保存' : '保存'` /
    `isMobile ? 'medium' : 'medium'` × 2）
  - `console.log` 2箇所（`console.error` は残置。エラー報告として妥当なため）

## 受け入れ基準
- [x] AppBar に空ラベルのボタンが存在しない
- [x] 保存ダイアログに日付・大会名・場所が表示される
- [x] 両分岐が同値の三項演算子が解消されている
- [x] `src/MainApp.tsx` に `console.log` が残っていない

## テスト
- `src/MainApp.test.tsx`: 保存ダイアログに日付・対戦カードが表示される
  ことを検証するテストを追加。修正前のコードに対して実行し Red
  （日付行が見つからず失敗）を確認したうえで、修正後 Green を確認済み
- デスクトップの試合日ボタン（`<Hidden smDown>`）は MUI の `Hidden` が
  `window.matchMedia` に依存するため、jsdom では常に非表示（そもそも
  DOM に現れない）になり自動テストで検証できなかった。修正内容は
  モバイル版の既存実装と同じパターンであることをコードレビューで確認
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check` ✅
- `npm test -- --watchAll=false`（29 suites / 182 tests）✅
- `npm run build` ✅

## 確認できなかった検証
- `npm start` によるデスクトップでの試合日ボタンの目視確認: このセッション
  内で `npm start` 自体は動作する状態だが（#243 で修正済み）、アプリの
  ログインが必要なため、今回は上記の自動テストとコードレビューで代替した

🤖 Generated with [Claude Code](https://claude.com/claude-code)