### PR TITLE
fix: チーム読み込み導線の二重実装を統合（打席データの無言破棄を含む）

### DIFF
--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -58,7 +58,6 @@ import {
   Player,
   AtBat,
   Game,
-  TeamSetting,
   RunEvent,
   RunEventType,
   OutEvent,
@@ -75,7 +74,6 @@ import {
   getSharedGameById,
   saveGameAsNew,
 } from './firebase/gameService';
-import { getTeamById, getUserTeams } from './firebase/teamService';
 import { useAuth } from './contexts/AuthContext';
 import Login from './components/Login';
 import HelpIcon from '@mui/icons-material/Help';
@@ -157,12 +155,6 @@ const MainApp: React.FC<{
 
   // チーム管理関連の状態
   const [showTeamManagement, setShowTeamManagement] = useState(false);
-  const [teamSelectionDialogOpen, setTeamSelectionDialogOpen] = useState(false);
-  const [teamSelectionMode, setTeamSelectionMode] = useState<'home' | 'away'>(
-    'home'
-  );
-  const [availableTeams, setAvailableTeams] = useState<TeamSetting[]>([]);
-  const [loadingTeams, setLoadingTeams] = useState(false);
 
   // 通算成績関連の状態
   const [showTeamStats, setShowTeamStats] = useState(false);
@@ -752,36 +744,6 @@ const MainApp: React.FC<{
     }
   };
 
-  const handleOpenTeamSelection = async (mode: 'home' | 'away') => {
-    if (!currentUser) {
-      setSnackbarMessage('チームを読み込むにはログインしてください');
-      setSnackbarSeverity('warning');
-      setSnackbarOpen(true);
-      return;
-    }
-
-    setTeamSelectionMode(mode);
-    setTeamSelectionDialogOpen(true);
-    setLoadingTeams(true);
-
-    try {
-      const teams = await getUserTeams();
-      setAvailableTeams(teams ?? []);
-    } catch (error) {
-      console.error('Failed to load teams:', error);
-      setSnackbarMessage(
-        error instanceof Error
-          ? `チーム一覧の取得に失敗しました: ${error.message}`
-          : 'チーム一覧の取得に失敗しました'
-      );
-      setSnackbarSeverity('error');
-      setSnackbarOpen(true);
-      setAvailableTeams([]);
-    } finally {
-      setLoadingTeams(false);
-    }
-  };
-
   // 既存の試合データを選択
   const handleSelectGame = async (gameId: string) => {
     try {
@@ -803,63 +765,6 @@ const MainApp: React.FC<{
     } catch (error: any) {
       console.error('Error loading game:', error);
       setSnackbarMessage(`読み込みに失敗しました: ${error.message}`);
-      setSnackbarSeverity('error');
-      setSnackbarOpen(true);
-    }
-  };
-
-  // チーム選択ダイアログを閉じる
-  const closeTeamSelectionDialog = () => {
-    setTeamSelectionDialogOpen(false);
-  };
-
-  // 選択したチームをゲームに設定
-  const handleSelectTeamForGame = async (teamSettingId: string) => {
-    try {
-      const teamSetting = await getTeamById(teamSettingId);
-      if (!teamSetting) {
-        throw new Error('チームデータの取得に失敗しました');
-      }
-
-      // 保存済みのチーム情報からゲーム用のチームデータを作成
-      const gameTeam: Team = {
-        id: teamSetting.id,
-        name: teamSetting.name,
-        players: teamSetting.players.map((player) => ({
-          id: player.id,
-          name: player.name,
-          number: player.number,
-          position: player.position,
-          isActive: true,
-          order: 0, // 初期値は0に設定
-        })),
-        atBats: [],
-      };
-
-      // ホームチームかアウェイチームのどちらを更新するか
-      if (teamSelectionMode === 'home') {
-        // setGame((prevGame) => ({
-        //   ...prevGame,
-        //   homeTeam: gameTeam,
-        // }));
-        gameActions.setHomeTeam(gameTeam);
-      } else {
-        // setGame((prevGame) => ({
-        //   ...prevGame,
-        //   awayTeam: gameTeam,
-        // }));
-        gameActions.setAwayTeam(gameTeam);
-      }
-
-      closeTeamSelectionDialog();
-      setSnackbarMessage(
-        `${teamSetting.name}を${teamSelectionMode === 'home' ? '後攻' : '先攻'}チームに設定しました`
-      );
-      setSnackbarSeverity('success');
-      setSnackbarOpen(true);
-    } catch (error: any) {
-      console.error('Failed to set team:', error);
-      setSnackbarMessage(`チーム設定に失敗しました: ${error.message}`);
       setSnackbarSeverity('error');
       setSnackbarOpen(true);
     }
@@ -1273,32 +1178,6 @@ const MainApp: React.FC<{
               isSharedMode={isSharedMode}
               onClick={handleOpenVenueDialog}
             />
-            {!isSharedMode && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'flex-end',
-                  gap: 1,
-                  flexWrap: 'wrap',
-                  mt: 1,
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={() => handleOpenTeamSelection('away')}
-                >
-                  先攻チームを読み込む
-                </Button>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={() => handleOpenTeamSelection('home')}
-                >
-                  後攻チームを読み込む
-                </Button>
-              </Box>
-            )}
             <Stepper
               activeStep={activeStep}
               alternativeLabel
@@ -1679,52 +1558,6 @@ const MainApp: React.FC<{
           <Button onClick={handleCloseVenueDialog} color="primary">
             設定
           </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* チーム選択ダイアログ */}
-      <Dialog
-        open={teamSelectionDialogOpen}
-        onClose={closeTeamSelectionDialog}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>
-          {teamSelectionMode === 'home' ? '後攻' : '先攻'}チームを選択
-        </DialogTitle>
-        <DialogContent>
-          {loadingTeams ? (
-            <Box display="flex" justifyContent="center" padding={3}>
-              <CircularProgress />
-            </Box>
-          ) : availableTeams.length === 0 ? (
-            <Typography>
-              登録済みのチームがありません。先に「チーム・選手管理」からチームを作成してください。
-            </Typography>
-          ) : (
-            <Box
-              sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}
-            >
-              {availableTeams.map((team) => (
-                <Button
-                  key={team.id}
-                  variant="outlined"
-                  onClick={() => handleSelectTeamForGame(team.id)}
-                  sx={{ justifyContent: 'flex-start', textAlign: 'left' }}
-                >
-                  <Box>
-                    <Typography variant="subtitle1">{team.name}</Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      選手数: {team.players?.length || 0}人
-                    </Typography>
-                  </Box>
-                </Button>
-              ))}
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeTeamSelectionDialog}>キャンセル</Button>
         </DialogActions>
       </Dialog>
 

--- a/src/components/TeamManager.tsx
+++ b/src/components/TeamManager.tsx
@@ -27,6 +27,7 @@ import { v4 as uuidv4 } from 'uuid';
 import PlayerList from './PlayerList';
 import { getUserTeams, getTeamById } from '../firebase/teamService';
 import { getNextBatterPlayerId } from '../services/BattingOrder';
+import { useAuth } from '../contexts/AuthContext';
 
 interface TeamManagerProps {
   team: Team;
@@ -39,6 +40,7 @@ const TeamManager: React.FC<TeamManagerProps> = ({
   onTeamUpdate,
   onRegisterAtBat,
 }) => {
+  const { currentUser } = useAuth();
   const [openPlayerDialog, setOpenPlayerDialog] = useState(false);
   const [editingPlayer, setEditingPlayer] = useState<Player | null>(null);
   const [playerName, setPlayerName] = useState('');
@@ -57,6 +59,9 @@ const TeamManager: React.FC<TeamManagerProps> = ({
   const [teamSelectionError, setTeamSelectionError] = useState<string | null>(
     null
   );
+  // 打席が既に記録された状態でチームを差し替える前の確認用
+  const [pendingTeamReplacement, setPendingTeamReplacement] =
+    useState<TeamSetting | null>(null);
 
   // teamプロップが変更されたらチーム名の状態を更新
   useEffect(() => {
@@ -178,6 +183,12 @@ const TeamManager: React.FC<TeamManagerProps> = ({
 
   // チーム選択ダイアログを開く
   const handleOpenTeamSelectionDialog = async () => {
+    if (!currentUser) {
+      setTeamSelectionError('チームを読み込むにはログインしてください');
+      setOpenTeamSelectionDialog(true);
+      return;
+    }
+
     try {
       setLoadingTeams(true);
       setTeamSelectionError(null);
@@ -199,12 +210,30 @@ const TeamManager: React.FC<TeamManagerProps> = ({
   // チーム選択ダイアログを閉じる
   const handleCloseTeamSelectionDialog = () => {
     setOpenTeamSelectionDialog(false);
+    setPendingTeamReplacement(null);
     // ダイアログを閉じるときに状態をリセット
     setTimeout(() => {
       setTeamSelectionError(null);
       setAvailableTeams([]);
     }, 300); // ダイアログのアニメーション終了後にリセット
   };
+
+  // 登録済みのチーム情報から現在の試合用のチームデータを作成する
+  const buildUpdatedTeam = (teamSetting: TeamSetting): Team => ({
+    ...team,
+    id: teamSetting.id,
+    name: teamSetting.name,
+    players:
+      teamSetting.players?.map((player) => ({
+        id: player.id,
+        name: player.name,
+        number: player.number,
+        position: player.position,
+        isActive: true,
+        order: 0, // 初期値は0に設定
+      })) || [],
+    // 注意: atBats は維持される（打席データを無言で破棄しない）
+  });
 
   // 選択したチームでデータを更新
   const handleSelectTeam = async (teamSettingId: string) => {
@@ -219,24 +248,15 @@ const TeamManager: React.FC<TeamManagerProps> = ({
         throw new Error('チームデータの取得に失敗しました');
       }
 
-      // 登録済みのチーム情報から現在の試合用のチームデータを作成
-      const updatedTeam: Team = {
-        ...team,
-        id: teamSetting.id,
-        name: teamSetting.name,
-        players:
-          teamSetting.players?.map((player) => ({
-            id: player.id,
-            name: player.name,
-            number: player.number,
-            position: player.position,
-            isActive: true,
-            order: 0, // 初期値は0に設定
-          })) || [],
-        // 注意: atBatsは維持されます
-      };
+      // 既にこの試合で打席が記録されている場合は、選手が入れ替わることを
+      // 確認してから反映する（打席データ自体は消えないが、記録済みの
+      // 打席が指す選手が変わるため、無言で進めない）
+      if (team.atBats.length > 0) {
+        setPendingTeamReplacement(teamSetting);
+        return;
+      }
 
-      onTeamUpdate(updatedTeam);
+      onTeamUpdate(buildUpdatedTeam(teamSetting));
       handleCloseTeamSelectionDialog();
     } catch (error: any) {
       console.error('チームの選択に失敗しました:', error);
@@ -246,6 +266,19 @@ const TeamManager: React.FC<TeamManagerProps> = ({
     } finally {
       setLoadingTeams(false);
     }
+  };
+
+  // 確認ダイアログでチーム差し替えを実行
+  const handleConfirmTeamReplacement = () => {
+    if (!pendingTeamReplacement) return;
+    onTeamUpdate(buildUpdatedTeam(pendingTeamReplacement));
+    setPendingTeamReplacement(null);
+    handleCloseTeamSelectionDialog();
+  };
+
+  // 確認ダイアログをキャンセル（チーム選択ダイアログには戻る）
+  const handleCancelTeamReplacement = () => {
+    setPendingTeamReplacement(null);
   };
 
   return (
@@ -422,6 +455,33 @@ const TeamManager: React.FC<TeamManagerProps> = ({
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseTeamSelectionDialog}>キャンセル</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 打席記録がある状態でのチーム差し替え確認ダイアログ */}
+      <Dialog
+        open={!!pendingTeamReplacement}
+        onClose={handleCancelTeamReplacement}
+      >
+        <DialogTitle>選手を入れ替えます</DialogTitle>
+        <DialogContent>
+          <Typography>
+            この試合には既に記録された打席があります。「
+            {pendingTeamReplacement?.name}
+            」を選択すると選手が入れ替わりますが、記録済みの打席データ自体は
+            削除されません（入れ替え後の選手一覧とは一致しなくなる場合が
+            あります）。よろしいですか？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelTeamReplacement}>キャンセル</Button>
+          <Button
+            onClick={handleConfirmTeamReplacement}
+            color="primary"
+            variant="contained"
+          >
+            入れ替える
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/components/__tests__/TeamManager.test.tsx
+++ b/src/components/__tests__/TeamManager.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import TeamManager from '../TeamManager';
+import { getUserTeams, getTeamById } from '../../firebase/teamService';
+import { Team, TeamSetting } from '../../types';
+
+jest.mock('../../firebase/teamService', () => ({
+  getUserTeams: jest.fn(),
+  getTeamById: jest.fn(),
+}));
+
+let mockCurrentUser: { uid: string; email: string } | null = {
+  uid: 'user-1',
+  email: 'me@example.com',
+};
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ currentUser: mockCurrentUser }),
+}));
+
+const mockedGetUserTeams = getUserTeams as jest.MockedFunction<
+  typeof getUserTeams
+>;
+const mockedGetTeamById = getTeamById as jest.MockedFunction<
+  typeof getTeamById
+>;
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 'team-1',
+  name: '先攻チーム',
+  players: [
+    {
+      id: 'p1',
+      name: '選手1',
+      number: '1',
+      position: 'CF',
+      isActive: true,
+      order: 1,
+    },
+  ],
+  atBats: [],
+  ...overrides,
+});
+
+const savedTeam: TeamSetting = {
+  id: 'saved-team-1',
+  name: '保存済みチーム',
+  players: [{ id: 'sp1', name: '保存選手1', number: '9', position: 'P' }],
+  userId: 'user-1',
+};
+
+const renderTeamManager = (team: Team, onTeamUpdate = jest.fn()) => {
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <TeamManager team={team} onTeamUpdate={onTeamUpdate} />
+    </ThemeProvider>
+  );
+  return { onTeamUpdate };
+};
+
+describe('TeamManager - チーム選択導線の統合', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser = { uid: 'user-1', email: 'me@example.com' };
+    mockedGetUserTeams.mockResolvedValue([savedTeam]);
+    mockedGetTeamById.mockResolvedValue(savedTeam);
+  });
+
+  test('未ログインの場合、チーム一覧を取得せずログインを促すメッセージを表示する', async () => {
+    mockCurrentUser = null;
+    const user = userEvent.setup();
+    renderTeamManager(makeTeam());
+
+    await user.click(screen.getByRole('button', { name: 'チームを選択' }));
+
+    expect(
+      await screen.findByText('チームを読み込むにはログインしてください')
+    ).toBeInTheDocument();
+    expect(mockedGetUserTeams).not.toHaveBeenCalled();
+  });
+
+  test('打席が未記録の場合は確認なしで即座にチームを反映する', async () => {
+    const user = userEvent.setup();
+    const { onTeamUpdate } = renderTeamManager(makeTeam({ atBats: [] }));
+
+    await user.click(screen.getByRole('button', { name: 'チームを選択' }));
+    await user.click(await screen.findByText('保存済みチーム'));
+
+    expect(onTeamUpdate).toHaveBeenCalledTimes(1);
+    expect(onTeamUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: '保存済みチーム', atBats: [] })
+    );
+  });
+
+  test('打席が記録済みの場合は確認ダイアログを挟み、キャンセルすると反映しない', async () => {
+    const user = userEvent.setup();
+    const existingAtBat = {
+      id: 'ab1',
+      playerId: 'p1',
+      inning: 1,
+      isTop: true,
+      result: 'IH' as const,
+      rbi: 0,
+      isOut: false,
+    };
+    const { onTeamUpdate } = renderTeamManager(
+      makeTeam({ atBats: [existingAtBat] })
+    );
+
+    await user.click(screen.getByRole('button', { name: 'チームを選択' }));
+    await user.click(await screen.findByText('保存済みチーム'));
+
+    expect(await screen.findByText('選手を入れ替えます')).toBeInTheDocument();
+    expect(onTeamUpdate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onTeamUpdate).not.toHaveBeenCalled();
+  });
+
+  test('打席が記録済みの場合、確認して「入れ替える」を押すと打席データを保持したまま反映する', async () => {
+    const user = userEvent.setup();
+    const existingAtBat = {
+      id: 'ab1',
+      playerId: 'p1',
+      inning: 1,
+      isTop: true,
+      result: 'IH' as const,
+      rbi: 0,
+      isOut: false,
+    };
+    const { onTeamUpdate } = renderTeamManager(
+      makeTeam({ atBats: [existingAtBat] })
+    );
+
+    await user.click(screen.getByRole('button', { name: 'チームを選択' }));
+    await user.click(await screen.findByText('保存済みチーム'));
+    await screen.findByText('選手を入れ替えます');
+
+    await user.click(screen.getByRole('button', { name: '入れ替える' }));
+
+    expect(onTeamUpdate).toHaveBeenCalledTimes(1);
+    expect(onTeamUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '保存済みチーム',
+        atBats: [existingAtBat],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## 概要
Closes #237

「登録済みチームを試合に読み込む」に、挙動の異なる実装が2系統あった。

| | 系統1（MainApp、削除） | 系統2（TeamManager、維持・強化） |
|---|---|---|
| 対象チーム | 先攻/後攻をボタンで明示選択 | 現在のタブのチーム |
| 打席データ | `atBats: []` で**無言破棄** | `...team` で維持 |
| 表示形式 | Button の縦並び | List + Divider |
| エラー時 | Snackbar | ダイアログ内インライン + 再試行 |
| 未ログイン | Snackbar で警告 | チェックなし |

## 対応方針と変更内容

新しい共有ダイアログを作るのではなく、**MainApp 側の実装を削除**した。
TeamManager の「チームを選択」は現在表示中のタブのチームに対して動作する
ため、先攻/後攻を切り替えてから使えば MainApp 側と同じ結果になり、
機能的な喪失はない。かつ TeamManager 側はエラー表示・打席データの扱いの
両方で元々安全な実装だった。

- **MainApp.tsx**: 「先攻/後攻チームを読み込む」ボタン、対応する state
  （`teamSelectionDialogOpen` 等）・ハンドラ（`handleOpenTeamSelection`
  等）・ダイアログ JSX を削除。未使用になった `getTeamById` /
  `getUserTeams` / `TeamSetting` の import も削除
- **TeamManager.tsx**（維持・強化）:
  - `useAuth()` から `currentUser` を取得し、未ログイン時はチーム一覧を
    取得せず「チームを読み込むにはログインしてください」を表示するよう
    にした（削除した MainApp 側にあった唯一のチェックを移植）
  - 現在のチームに既に打席が記録されている（`team.atBats.length > 0`）
    場合、選択した瞬間に反映せず確認ダイアログを挟むようにした。打席
    データ自体は削除しない旨を明示した上で「入れ替える」を選ぶまで反映
    しない。打席が未記録の場合は従来通り即座に反映される

## 受け入れ基準
- [x] チーム読み込みのダイアログ実装が1つに統合されている
- [x] 既に打席が記録されている状態でのチーム差し替え時の挙動が定義され、無言でのデータ破棄がない
- [x] 未ログイン時の扱いがどの経路でも同じ

## テスト
- `src/components/__tests__/TeamManager.test.tsx`（新規、4ケース）:
  未ログイン時のメッセージ、打席未記録時の即時反映、打席記録済み時の
  確認ダイアログ（キャンセル/確定の両方）を検証。修正前のコードに対して
  実行し、未ログインケースと確認ダイアログの2ケース（計3テスト）が
  タイムアウトで Red になることを確認したうえで、修正後 Green を確認済み
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx prettier --check` ✅
- `npm test -- --watchAll=false`（30 suites / 185 tests）✅
- `npm run build` ✅

## 確認できなかった検証
- `npm start` による実機でのチーム読み込みフロー目視確認: アプリの
  ログインが必要なため、今回は上記の自動テストとコードレビューで代替した

🤖 Generated with [Claude Code](https://claude.com/claude-code)