### PR TITLE
fix: アクセシビリティ修正（TournamentVenue・SectionCard・viewport 単位）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,11 +16,12 @@
 .App-header {
   background-color: #282c34;
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
+  font-size: clamp(1rem, calc(0.625rem + 2vmin), 1.5rem);
   color: white;
 }
 

--- a/src/components/SectionCard.tsx
+++ b/src/components/SectionCard.tsx
@@ -13,6 +13,7 @@ interface SectionCardProps extends PaperProps {
   actions?: React.ReactNode;
   children: React.ReactNode;
   titleVariant?: TypographyProps['variant'];
+  titleComponent?: React.ElementType;
 }
 
 const SectionCard: React.FC<SectionCardProps> = ({
@@ -20,6 +21,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
   actions,
   children,
   titleVariant = 'subtitle1',
+  titleComponent = 'h2',
   sx,
   ...paperProps
 }) => {
@@ -27,15 +29,17 @@ const SectionCard: React.FC<SectionCardProps> = ({
 
   return (
     <Paper
-      component="section"
-      aria-labelledby={headingId}
       elevation={1}
       {...paperProps}
-      sx={{
-        p: { xs: 2, sm: 3 },
-        mb: 3,
-        ...sx,
-      }}
+      component="section"
+      aria-labelledby={headingId}
+      sx={[
+        {
+          p: { xs: 2, sm: 3 },
+          mb: 3,
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
     >
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
@@ -45,7 +49,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
       >
         <Typography
           id={headingId}
-          component="h2"
+          component={titleComponent}
           variant={titleVariant}
           fontWeight={600}
         >

--- a/src/components/SectionCard.tsx
+++ b/src/components/SectionCard.tsx
@@ -8,7 +8,10 @@ import {
   TypographyProps,
 } from '@mui/material';
 
-interface SectionCardProps extends PaperProps {
+interface SectionCardProps extends Omit<
+  PaperProps,
+  'component' | 'aria-labelledby'
+> {
   title: string;
   actions?: React.ReactNode;
   children: React.ReactNode;
@@ -38,7 +41,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
           p: { xs: 2, sm: 3 },
           mb: 3,
         },
-        ...(Array.isArray(sx) ? sx : [sx]),
+        ...(sx ? (Array.isArray(sx) ? sx : [sx]) : []),
       ]}
     >
       <Stack

--- a/src/components/TournamentVenue.tsx
+++ b/src/components/TournamentVenue.tsx
@@ -23,7 +23,7 @@ const TournamentVenue: React.FC<Props> = ({
     if (venue) {
       return venue;
     }
-    return isSharedMode ? '' : '大会名をクリックして設定';
+    return isClickable ? '大会名をクリックして設定' : '';
   })();
 
   return (
@@ -45,7 +45,11 @@ const TournamentVenue: React.FC<Props> = ({
       }}
       onClick={isClickable ? onClick : undefined}
     >
-      <Typography variant="subtitle1" align="center">
+      <Typography
+        variant="subtitle1"
+        align="center"
+        component={isClickable ? 'span' : 'p'}
+      >
         {displayText}
       </Typography>
     </Box>

--- a/src/components/TournamentVenue.tsx
+++ b/src/components/TournamentVenue.tsx
@@ -13,22 +13,43 @@ const TournamentVenue: React.FC<Props> = ({
   venue,
   isSharedMode,
   onClick,
-}) => (
-  <Box
-    sx={{
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      mb: 2,
-      cursor: isSharedMode ? 'default' : 'pointer',
-    }}
-    onClick={!isSharedMode ? onClick : undefined}
-  >
-    <Typography variant="subtitle1" align="center">
-      {tournament ? tournament : isSharedMode ? '' : '大会名をクリックして設定'}
-      {venue && ` @ ${venue}`}
-    </Typography>
-  </Box>
-);
+}) => {
+  const isClickable = !isSharedMode && Boolean(onClick);
+
+  const displayText = (() => {
+    if (tournament) {
+      return venue ? `${tournament} @ ${venue}` : tournament;
+    }
+    if (venue) {
+      return venue;
+    }
+    return isSharedMode ? '' : '大会名をクリックして設定';
+  })();
+
+  return (
+    <Box
+      component={isClickable ? 'button' : 'div'}
+      type={isClickable ? 'button' : undefined}
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        mb: 2,
+        cursor: isClickable ? 'pointer' : 'default',
+        background: 'none',
+        border: 0,
+        p: 0,
+        font: 'inherit',
+        color: 'inherit',
+        width: '100%',
+      }}
+      onClick={isClickable ? onClick : undefined}
+    >
+      <Typography variant="subtitle1" align="center">
+        {displayText}
+      </Typography>
+    </Box>
+  );
+};
 
 export default TournamentVenue;

--- a/src/components/__tests__/SectionCard.test.tsx
+++ b/src/components/__tests__/SectionCard.test.tsx
@@ -34,4 +34,50 @@ describe('SectionCard', () => {
 
     expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
   });
+
+  test('renders custom titleComponent', () => {
+    renderWithTheme(
+      <SectionCard title="試合情報" titleComponent="h3">
+        <p>content</p>
+      </SectionCard>
+    );
+
+    const heading = screen.getByRole('heading', { name: '試合情報', level: 3 });
+    expect(heading).toBeInTheDocument();
+  });
+
+  test('preserves section element and aria-labelledby attribute with paperProps', () => {
+    renderWithTheme(
+      <SectionCard title="試合結果" data-testid="result-card" elevation={3}>
+        <p>content</p>
+      </SectionCard>
+    );
+
+    const section = screen.getByTestId('result-card');
+    expect(section.tagName.toLowerCase()).toBe('section');
+    expect(section).toHaveAttribute('aria-labelledby');
+    const headingId = section.getAttribute('aria-labelledby');
+    const heading = screen.getByRole('heading', { name: '試合結果' });
+    expect(heading).toHaveAttribute('id', headingId);
+  });
+
+  test('supports array and function SxProps without throwing', () => {
+    expect(() => {
+      renderWithTheme(
+        <SectionCard
+          title="スタイルテスト"
+          sx={[
+            { backgroundColor: 'rgb(240, 240, 240)' },
+            (theme) => ({ color: theme.palette.text.primary }),
+          ]}
+        >
+          <p>content</p>
+        </SectionCard>
+      );
+    }).not.toThrow();
+
+    expect(
+      screen.getByRole('heading', { name: 'スタイルテスト' })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/TournamentVenue.test.tsx
+++ b/src/components/__tests__/TournamentVenue.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import TournamentVenue from '../TournamentVenue';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={createTheme()}>{ui}</ThemeProvider>);
+
+describe('TournamentVenue', () => {
+  test('renders placeholder text when tournament is not provided and not in shared mode', () => {
+    renderWithTheme(<TournamentVenue onClick={jest.fn()} />);
+
+    expect(screen.getByText('大会名をクリックして設定')).toBeInTheDocument();
+  });
+
+  test('renders empty text when tournament and venue are not provided in shared mode', () => {
+    const { container } = renderWithTheme(
+      <TournamentVenue isSharedMode={true} />
+    );
+
+    expect(
+      screen.queryByText('大会名をクリックして設定')
+    ).not.toBeInTheDocument();
+    expect(container.textContent).toBe('');
+  });
+
+  test('renders venue without dangling @ prefix when tournament is not provided', () => {
+    renderWithTheme(<TournamentVenue venue="東京ドーム" isSharedMode={true} />);
+
+    expect(screen.getByText('東京ドーム')).toBeInTheDocument();
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+  });
+
+  test('renders both tournament and venue separated with @ when both provided', () => {
+    renderWithTheme(
+      <TournamentVenue
+        tournament="夏季大会"
+        venue="阪神甲子園球場"
+        onClick={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('夏季大会 @ 阪神甲子園球場')).toBeInTheDocument();
+  });
+
+  test('is keyboard accessible as a button when onClick is provided and not shared mode', () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <TournamentVenue tournament="夏季大会" onClick={handleClick} />
+    );
+
+    const button = screen.getByRole('button', { name: '夏季大会' });
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('is not rendered as a button when in shared mode or onClick is not provided', () => {
+    renderWithTheme(
+      <TournamentVenue
+        tournament="夏季大会"
+        isSharedMode={true}
+        onClick={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('夏季大会')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Issue #203 に対応し、アクセシビリティおよびレイアウトの修正を実施しました。

## 変更内容
- **TournamentVenue.tsx**:
  - クリック可能な場合に `component="button"` としてキーボード操作およびスクリーンリーダー対応を追加
  - ネストした三項演算子を整理し、大会名未設定時に余計な `@` 接頭辞が表示される問題を解消
  - `component={isClickable ? 'span' : 'p'}` による有効な HTML ネスティング
- **SectionCard.tsx**:
  - `titleComponent` prop を追加し、見出しレベル（h2, h3 等）の柔軟な指定を可能に
  - `sx` prop を配列形式で合成するように修正し、配列や関数形式の SxProps をサポート
  - `SectionCardProps` で `component` と `aria-labelledby` を Omit し、セマンティクスを保護
- **App.css**:
  - `font-size` を `clamp(1rem, calc(0.625rem + 2vmin), 1.5rem)` に更新（rem 基準）
  - モバイルの動的ツールバーに対応するため `min-height: 100dvh` を追加
- **テスト**:
  - `TournamentVenue.test.tsx` の新規追加
  - `SectionCard.test.tsx` に `titleComponent`, `sx`, a11y 属性のテストを追加

## 実行したテスト
- `npm run ci:local` (全 36 スイート 230 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (指摘事項を反映済み)

Closes #203
