### PR TITLE
test: テストカバレッジギャップの解消（AtBatForm 機能テスト・AtBatHistory a11y・HelpDialog・テーマトークン）

### DIFF
--- a/src/components/AtBatHistory.tsx
+++ b/src/components/AtBatHistory.tsx
@@ -199,6 +199,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                                 size="small"
                                 onClick={() => onEditAtBat(atBat)}
                                 color="primary"
+                                aria-label="編集"
                               >
                                 <EditIcon fontSize="small" />
                               </IconButton>
@@ -210,6 +211,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                                 size="small"
                                 onClick={() => onDeleteAtBat(atBat.id)}
                                 color="error"
+                                aria-label="削除"
                               >
                                 <DeleteIcon fontSize="small" />
                               </IconButton>
@@ -265,6 +267,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                             size="small"
                             onClick={() => onDeleteRunEvent(event.id)}
                             color="error"
+                            aria-label="削除"
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>
@@ -316,6 +319,7 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                             size="small"
                             onClick={() => onDeleteOutEvent(event.id)}
                             color="secondary"
+                            aria-label="削除"
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>

--- a/src/components/AtBatHistory.tsx
+++ b/src/components/AtBatHistory.tsx
@@ -71,6 +71,9 @@ const hitResultLabels: Record<HitResult, string> = {
   OTH: 'その他',
 };
 
+const EDIT_LABEL = '編集';
+const DELETE_LABEL = '削除';
+
 const AtBatHistory: React.FC<AtBatHistoryProps> = ({
   atBats,
   players,
@@ -194,24 +197,24 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                       <TableCell>
                         <Box sx={{ display: 'flex' }}>
                           {onEditAtBat && (
-                            <Tooltip title="編集">
+                            <Tooltip title={EDIT_LABEL}>
                               <IconButton
                                 size="small"
                                 onClick={() => onEditAtBat(atBat)}
                                 color="primary"
-                                aria-label="編集"
+                                aria-label={EDIT_LABEL}
                               >
                                 <EditIcon fontSize="small" />
                               </IconButton>
                             </Tooltip>
                           )}
                           {onDeleteAtBat && (
-                            <Tooltip title="削除">
+                            <Tooltip title={DELETE_LABEL}>
                               <IconButton
                                 size="small"
                                 onClick={() => onDeleteAtBat(atBat.id)}
                                 color="error"
-                                aria-label="削除"
+                                aria-label={DELETE_LABEL}
                               >
                                 <DeleteIcon fontSize="small" />
                               </IconButton>
@@ -262,12 +265,12 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                     <TableCell>{event.note || '-'}</TableCell>
                     {onDeleteRunEvent && (
                       <TableCell>
-                        <Tooltip title="削除">
+                        <Tooltip title={DELETE_LABEL}>
                           <IconButton
                             size="small"
                             onClick={() => onDeleteRunEvent(event.id)}
                             color="error"
-                            aria-label="削除"
+                            aria-label={DELETE_LABEL}
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>
@@ -314,12 +317,12 @@ const AtBatHistory: React.FC<AtBatHistoryProps> = ({
                     <TableCell>{event.note || '-'}</TableCell>
                     {onDeleteOutEvent && (
                       <TableCell>
-                        <Tooltip title="削除">
+                        <Tooltip title={DELETE_LABEL}>
                           <IconButton
                             size="small"
                             onClick={() => onDeleteOutEvent(event.id)}
                             color="secondary"
-                            aria-label="削除"
+                            aria-label={DELETE_LABEL}
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>

--- a/src/components/__tests__/AtBatForm.test.tsx
+++ b/src/components/__tests__/AtBatForm.test.tsx
@@ -143,4 +143,112 @@ describe('AtBatForm', () => {
       expect.objectContaining({ result: 'HR', isOut: false })
     );
   });
+
+  test('選手未選択時は選択を促すメッセージを表示する', () => {
+    renderForm({
+      player: null,
+      inning: 1,
+      isTop: true,
+      onAddAtBat: jest.fn(),
+      editingAtBat: null,
+    });
+
+    expect(
+      screen.getByText('選手リストから選手をクリックして選択してください')
+    ).toBeInTheDocument();
+  });
+
+  test('編集モードで選手がnullの場合は不明な選手と表示する', () => {
+    renderForm({
+      player: null,
+      inning: 1,
+      isTop: true,
+      onAddAtBat: jest.fn(),
+      editingAtBat,
+      onUpdateAtBat: jest.fn(),
+    });
+
+    expect(
+      screen.getByRole('heading', { name: /打席結果編集: 不明な選手/ })
+    ).toBeInTheDocument();
+  });
+
+  test('キャンセルボタンで onCancelEdit が呼ばれる', async () => {
+    const onCancelEdit = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat: jest.fn(),
+      editingAtBat,
+      onUpdateAtBat: jest.fn(),
+      onCancelEdit,
+    });
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+    await user.click(cancelButton);
+
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  test('メモと打点を入力して送信できる', async () => {
+    const onAddAtBat = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat,
+    });
+
+    // ヒットを選択
+    await user.click(screen.getByRole('button', { name: 'レフトヒット' }));
+
+    // 打点を設定（MUI Select）
+    const rbiSelect = screen.getByLabelText('打点');
+    await user.click(rbiSelect);
+    const rbiOption = await screen.findByRole('option', { name: '2' });
+    await user.click(rbiOption);
+
+    // メモを入力
+    const memoInput = screen.getByLabelText(/メモ/);
+    await user.type(memoInput, 'レフト線へのライナー');
+
+    // 登録
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    expect(onAddAtBat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: 'LH',
+        rbi: 2,
+        description: 'レフト線へのライナー',
+        isOut: false,
+      })
+    );
+  });
+
+  test('アウト結果が正しく isOut: true として送信される', async () => {
+    const onAddAtBat = jest.fn();
+    const user = userEvent.setup();
+
+    renderForm({
+      player,
+      inning: 1,
+      isTop: true,
+      onAddAtBat,
+    });
+
+    await user.click(screen.getByRole('button', { name: '三振' }));
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    expect(onAddAtBat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: 'SO',
+        isOut: true,
+      })
+    );
+  });
 });

--- a/src/components/__tests__/AtBatHistory.a11y.test.tsx
+++ b/src/components/__tests__/AtBatHistory.a11y.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from '../../setupTests';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import AtBatHistory from '../AtBatHistory';
+import { AtBat, Player, HitResult, RunEvent, OutEvent } from '../../types';
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  const theme = createTheme({});
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+const mockPlayers: Player[] = [
+  {
+    id: 'p1',
+    name: '山田太郎',
+    number: '1',
+    position: '投手',
+    isActive: true,
+    order: 1,
+  },
+];
+
+const mockAtBats: AtBat[] = [
+  {
+    id: 'ab1',
+    playerId: 'p1',
+    inning: 1,
+    isTop: true,
+    result: 'HR' as HitResult,
+    description: '特大ホームラン',
+    rbi: 2,
+    isOut: false,
+  },
+];
+
+const mockRunEvents: RunEvent[] = [
+  {
+    id: 're1',
+    inning: 1,
+    isTop: true,
+    runType: 'ワイルドピッチ',
+    runCount: 1,
+    note: '暴投で生還',
+    timestamp: Date.now(),
+  },
+];
+
+const mockOutEvents: OutEvent[] = [
+  {
+    id: 'oe1',
+    inning: 1,
+    isTop: true,
+    outType: '盗塁死',
+    note: '二塁刺殺',
+    timestamp: Date.now(),
+  },
+];
+
+describe('AtBatHistory accessibility', () => {
+  test('has no axe violations with complete history', async () => {
+    const { container } = renderWithTheme(
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+        runEvents={mockRunEvents}
+        outEvents={mockOutEvents}
+        onEditAtBat={jest.fn()}
+        onDeleteAtBat={jest.fn()}
+        onDeleteRunEvent={jest.fn()}
+        onDeleteOutEvent={jest.fn()}
+      />
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('provides accessible names for all action buttons', () => {
+    renderWithTheme(
+      <AtBatHistory
+        atBats={mockAtBats}
+        players={mockPlayers}
+        inning={1}
+        isTop={true}
+        runEvents={mockRunEvents}
+        outEvents={mockOutEvents}
+        onEditAtBat={jest.fn()}
+        onDeleteAtBat={jest.fn()}
+        onDeleteRunEvent={jest.fn()}
+        onDeleteOutEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    expect(deleteButtons).toHaveLength(3);
+  });
+});

--- a/src/components/__tests__/AtBatHistory.a11y.test.tsx
+++ b/src/components/__tests__/AtBatHistory.a11y.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from '../../setupTests';
+import { axe } from '../../test/axe';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import AtBatHistory from '../AtBatHistory';
 import { AtBat, Player, HitResult, RunEvent, OutEvent } from '../../types';

--- a/src/components/__tests__/HelpDialog.a11y.test.tsx
+++ b/src/components/__tests__/HelpDialog.a11y.test.tsx
@@ -4,7 +4,6 @@ import { axe } from '../../test/axe';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import HelpDialog from '../HelpDialog';
 
-
 const renderWithTheme = (ui: React.ReactElement) => {
   const theme = createTheme({});
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);

--- a/src/components/__tests__/HelpDialog.a11y.test.tsx
+++ b/src/components/__tests__/HelpDialog.a11y.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { axe } from '../../test/axe';
-
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import HelpDialog from '../HelpDialog';
+
 
 const renderWithTheme = (ui: React.ReactElement) => {
   const theme = createTheme({});
@@ -17,5 +17,43 @@ describe('HelpDialog accessibility', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  test('calls onClose when close icon button is clicked', () => {
+    const handleClose = jest.fn();
+    renderWithTheme(<HelpDialog open={true} onClose={handleClose} />);
+
+    const closeIconButton = screen.getByRole('button', { name: 'close' });
+    fireEvent.click(closeIconButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose when bottom 閉じる button is clicked', () => {
+    const handleClose = jest.fn();
+    renderWithTheme(<HelpDialog open={true} onClose={handleClose} />);
+
+    const closeButton = screen.getByRole('button', { name: '閉じる' });
+    fireEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose when Escape key is pressed', () => {
+    const handleClose = jest.fn();
+    renderWithTheme(<HelpDialog open={true} onClose={handleClose} />);
+
+    fireEvent.keyDown(screen.getByRole('dialog'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not display dialog when open is false', () => {
+    renderWithTheme(<HelpDialog open={false} onClose={() => {}} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/src/theme/__tests__/tokens.test.ts
+++ b/src/theme/__tests__/tokens.test.ts
@@ -1,6 +1,30 @@
 import { getNewTheme, fontFamilies, accessibilityTokens } from '../tokens';
 
-describe('theme tokens', () => {
+const hexToRgb = (hex: string): [number, number, number] => {
+  const cleaned = hex.replace('#', '');
+  const num = parseInt(cleaned, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+};
+
+const getRelativeLuminance = (r: number, g: number, b: number): number => {
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+};
+
+const getContrastRatio = (hex1: string, hex2: string): number => {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const l1 = getRelativeLuminance(r1, g1, b1);
+  const l2 = getRelativeLuminance(r2, g2, b2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+describe('theme tokens & contrast compliance', () => {
   test('exports consistent font families', () => {
     expect(fontFamilies.base).toBe(
       "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
@@ -30,4 +54,23 @@ describe('theme tokens', () => {
     expect(accessibilityTokens?.touchTarget?.minHeight).toBe('48px');
     expect(accessibilityTokens?.touchTarget?.minWidth).toBe('48px');
   });
+
+  test('focus visible tokens have distinct outline width', () => {
+    expect(accessibilityTokens?.focusVisible?.outline).toContain('2px');
+    expect(accessibilityTokens?.focusVisible?.outlineOffset).toBe('2px');
+  });
+
+  test('primary colors meet contrast expectations', () => {
+    const lightTheme = getNewTheme('light');
+    const darkTheme = getNewTheme('dark');
+
+    // Primary button contrast on dark mode background (#0F172A)
+    const darkBg = darkTheme.palette.background.default;
+    const primaryMain = lightTheme.palette.primary.main;
+    const contrastOnDark = getContrastRatio(darkBg, primaryMain);
+
+    // WCAG AA for UI components is at least 3.0:1
+    expect(contrastOnDark).toBeGreaterThanOrEqual(3.0);
+  });
 });
+

--- a/src/theme/__tests__/tokens.test.ts
+++ b/src/theme/__tests__/tokens.test.ts
@@ -73,4 +73,3 @@ describe('theme tokens & contrast compliance', () => {
     expect(contrastOnDark).toBeGreaterThanOrEqual(3.0);
   });
 });
-


### PR DESCRIPTION
## 概要
Issue #207 に対応し、主要コンポーネントのテストカバレッジギャップ解消とアクセシビリティテストの追加を実施しました。

## 変更内容
- **AtBatForm**:
  - `AtBatForm.test.tsx` にメモ入力、打点選択、編集キャンセル、選手未選択/不明な選手時の表示、アウト結果の判定（isOut）を網羅する機能テストを追加
- **AtBatHistory**:
  - `AtBatHistory.a11y.test.tsx` を新規追加し、axe 検証およびアクションボタン（編集・削除）のアクセシブルネーム検証を実装
  - `AtBatHistory.tsx` の Tooltip / IconButton に共通の `EDIT_LABEL` / `DELETE_LABEL` 定数と `aria-label` を設定
- **HelpDialog**:
  - `HelpDialog.a11y.test.tsx` に閉じるアイコンボタン、下部「閉じる」ボタン、Escape キー押下、非表示状態（`open={false}`）のテストを追加
- **テーマトークン**:
  - `src/theme/__tests__/tokens.test.ts` を追加し、タッチターゲット最小サイズ（48px）、フォーカスリング、WCAG コントラスト比を検証

## 実行したテスト
- `npm run ci:local` (全 37 スイート 235 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (指摘事項を反映済み)

Closes #207
