### PR TITLE
fix(mobile): モバイル操作性の改善（選手一覧のカードレイアウト化・見出し重複解消・Snackbar位置調整）

### DIFF
--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -89,6 +89,7 @@ describe('MainApp - 打席登録フロー', () => {
     renderMainApp();
 
     await registerAtBatFor(user, '選手1');
+    await screen.findByRole('heading', { name: /打席結果登録/ });
 
     expect(await screen.findByRole('button', { name: '登録' })).toBeDisabled();
   }, 30000);

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -1609,7 +1609,11 @@ const MainApp: React.FC<{
         open={snackbarOpen}
         autoHideDuration={snackbarSeverity === 'info' ? null : 6000}
         onClose={() => setSnackbarOpen(false)}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        anchorOrigin={
+          isMobile
+            ? { vertical: 'bottom', horizontal: 'center' }
+            : { vertical: 'top', horizontal: 'center' }
+        }
       >
         <Alert
           onClose={() => setSnackbarOpen(false)}

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -74,6 +74,67 @@ const PlayerList: React.FC<PlayerListProps> = ({
   // 打順選択用の選択肢を生成（1～9）
   const orderOptions = Array.from({ length: 9 }, (_, i) => i + 1);
 
+  // 打順セレクトまたは読み取り専用表示のレンダラー
+  const renderOrderControl = (
+    player: Player,
+    minHeight?: number,
+    minWidth?: number
+  ) => {
+    if (onUpdatePlayerOrder) {
+      return (
+        <FormControl
+          size="small"
+          sx={{ minWidth: minWidth ?? (isMobile ? 80 : 65) }}
+        >
+          <Select
+            value={player.order === 0 ? '' : player.order}
+            onChange={(e: SelectChangeEvent<number>) =>
+              handleOrderChange(player.id, e)
+            }
+            displayEmpty
+            aria-label={`${player.name}の打順`}
+            sx={minHeight ? { minHeight } : undefined}
+          >
+            <MenuItem value="">
+              <em>未設定</em>
+            </MenuItem>
+            {orderOptions.map((order) => (
+              <MenuItem key={order} value={order}>
+                {order}番
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      );
+    }
+    if (isMobile) {
+      return (
+        <Chip
+          size="small"
+          label={player.order === 0 ? '未設定' : `${player.order}番`}
+        />
+      );
+    }
+    return player.order || '未設定';
+  };
+
+  // 選手情報編集ボタンのレンダラー
+  const renderEditButton = (playerId: string, isLarge?: boolean) => {
+    if (!onEditPlayer) return null;
+    return (
+      <Tooltip title="選手情報を編集">
+        <IconButton
+          size={isLarge ? 'medium' : 'small'}
+          onClick={() => onEditPlayer(playerId)}
+          aria-label="選手情報を編集"
+          sx={isLarge ? { minHeight: 48, minWidth: 48 } : undefined}
+        >
+          <EditIcon fontSize={isLarge ? 'medium' : 'small'} />
+        </IconButton>
+      </Tooltip>
+    );
+  };
+
   if (isMobile) {
     return (
       <Box sx={{ mb: 3 }}>
@@ -125,7 +186,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                       flexWrap: 'wrap',
                     }}
                   >
-                    <Typography variant="subtitle1" fontWeight="bold">
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
                       #{player.number} {player.name}
                     </Typography>
                     {isNextBatter && (
@@ -143,28 +204,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                     />
                   </Box>
 
-                  {onUpdatePlayerOrder && (
-                    <FormControl size="small" sx={{ minWidth: 80 }}>
-                      <Select
-                        value={player.order === 0 ? '' : player.order}
-                        onChange={(e: SelectChangeEvent<number>) =>
-                          handleOrderChange(player.id, e)
-                        }
-                        displayEmpty
-                        aria-label={`${player.name}の打順`}
-                        sx={{ minHeight: 48 }}
-                      >
-                        <MenuItem value="">
-                          <em>未設定</em>
-                        </MenuItem>
-                        {orderOptions.map((order) => (
-                          <MenuItem key={order} value={order}>
-                            {order}番
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  )}
+                  {renderOrderControl(player, 48, 80)}
                 </Box>
 
                 <Box
@@ -198,17 +238,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                       控えに
                     </Button>
                   )}
-                  {onEditPlayer && (
-                    <Tooltip title="選手情報を編集">
-                      <IconButton
-                        onClick={() => onEditPlayer(player.id)}
-                        aria-label="選手情報を編集"
-                        sx={{ minHeight: 48, minWidth: 48 }}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                    </Tooltip>
-                  )}
+                  {renderEditButton(player.id, true)}
                 </Box>
               </Paper>
             );
@@ -265,7 +295,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                       flexWrap: 'wrap',
                     }}
                   >
-                    <Typography variant="subtitle1" fontWeight="bold">
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
                       #{player.number} {player.name}
                     </Typography>
                     <Chip
@@ -275,28 +305,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                     />
                   </Box>
 
-                  {onUpdatePlayerOrder && (
-                    <FormControl size="small" sx={{ minWidth: 80 }}>
-                      <Select
-                        value={player.order === 0 ? '' : player.order}
-                        onChange={(e: SelectChangeEvent<number>) =>
-                          handleOrderChange(player.id, e)
-                        }
-                        displayEmpty
-                        aria-label={`${player.name}の打順`}
-                        sx={{ minHeight: 48 }}
-                      >
-                        <MenuItem value="">
-                          <em>未設定</em>
-                        </MenuItem>
-                        {orderOptions.map((order) => (
-                          <MenuItem key={order} value={order}>
-                            {order}番
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  )}
+                  {renderOrderControl(player, 48, 80)}
                 </Box>
 
                 <Box
@@ -318,17 +327,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                       出場させる
                     </Button>
                   )}
-                  {onEditPlayer && (
-                    <Tooltip title="選手情報を編集">
-                      <IconButton
-                        onClick={() => onEditPlayer(player.id)}
-                        aria-label="選手情報を編集"
-                        sx={{ minHeight: 48, minWidth: 48 }}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                    </Tooltip>
-                  )}
+                  {renderEditButton(player.id, true)}
                 </Box>
               </Paper>
             ))}
@@ -373,28 +372,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                   }}
                 >
                   <TableCell>
-                    {onUpdatePlayerOrder ? (
-                      <FormControl size="small" sx={{ minWidth: 65 }}>
-                        <Select
-                          value={player.order === 0 ? '' : player.order}
-                          onChange={(e: SelectChangeEvent<number>) =>
-                            handleOrderChange(player.id, e)
-                          }
-                          displayEmpty
-                        >
-                          <MenuItem value="">
-                            <em>未設定</em>
-                          </MenuItem>
-                          {orderOptions.map((order) => (
-                            <MenuItem key={order} value={order}>
-                              {order}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    ) : (
-                      player.order || '未設定'
-                    )}
+                    {renderOrderControl(player, undefined, 65)}
                   </TableCell>
                   <TableCell>{player.number}</TableCell>
                   <TableCell>
@@ -447,17 +425,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           控えに
                         </Button>
                       )}
-                      {onEditPlayer && (
-                        <Tooltip title="選手情報を編集">
-                          <IconButton
-                            size="small"
-                            onClick={() => onEditPlayer(player.id)}
-                            aria-label="選手情報を編集"
-                          >
-                            <EditIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                      )}
+                      {renderEditButton(player.id)}
                     </Box>
                   </TableCell>
                 </TableRow>
@@ -508,28 +476,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                   }}
                 >
                   <TableCell>
-                    {onUpdatePlayerOrder ? (
-                      <FormControl size="small" sx={{ minWidth: 65 }}>
-                        <Select
-                          value={player.order === 0 ? '' : player.order}
-                          onChange={(e: SelectChangeEvent<number>) =>
-                            handleOrderChange(player.id, e)
-                          }
-                          displayEmpty
-                        >
-                          <MenuItem value="">
-                            <em>未設定</em>
-                          </MenuItem>
-                          {orderOptions.map((order) => (
-                            <MenuItem key={order} value={order}>
-                              {order}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    ) : (
-                      player.order || '未設定'
-                    )}
+                    {renderOrderControl(player, undefined, 65)}
                   </TableCell>
                   <TableCell>{player.number}</TableCell>
                   <TableCell>{player.name}</TableCell>
@@ -555,17 +502,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           出場させる
                         </Button>
                       )}
-                      {onEditPlayer && (
-                        <Tooltip title="選手情報を編集">
-                          <IconButton
-                            size="small"
-                            onClick={() => onEditPlayer(player.id)}
-                            aria-label="選手情報を編集"
-                          >
-                            <EditIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                      )}
+                      {renderEditButton(player.id)}
                     </Box>
                   </TableCell>
                 </TableRow>

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -74,16 +74,276 @@ const PlayerList: React.FC<PlayerListProps> = ({
   // 打順選択用の選択肢を生成（1～9）
   const orderOptions = Array.from({ length: 9 }, (_, i) => i + 1);
 
+  if (isMobile) {
+    return (
+      <Box sx={{ mb: 3 }}>
+        {/* 出場中の選手セクション */}
+        <Typography
+          variant="subtitle1"
+          sx={{
+            px: 2,
+            py: 1,
+            fontWeight: 'bold',
+            bgcolor: 'action.hover',
+            borderRadius: 1,
+            mb: 1.5,
+          }}
+        >
+          出場中の選手
+        </Typography>
+
+        {activePlayers.length > 0 ? (
+          activePlayers.map((player) => {
+            const isNextBatter = player.id === nextBatterPlayerId;
+            return (
+              <Paper
+                key={player.id}
+                variant="outlined"
+                sx={{
+                  p: 2,
+                  mb: 1.5,
+                  ...(isNextBatter && {
+                    borderColor: 'primary.main',
+                    bgcolor: 'action.selected',
+                  }),
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                    mb: 1.5,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    <Typography variant="subtitle1" fontWeight="bold">
+                      #{player.number} {player.name}
+                    </Typography>
+                    {isNextBatter && (
+                      <Chip
+                        label="次打者"
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                      />
+                    )}
+                    <Chip
+                      label={player.position}
+                      size="small"
+                      variant="filled"
+                    />
+                  </Box>
+
+                  {onUpdatePlayerOrder && (
+                    <FormControl size="small" sx={{ minWidth: 80 }}>
+                      <Select
+                        value={player.order === 0 ? '' : player.order}
+                        onChange={(e: SelectChangeEvent<number>) =>
+                          handleOrderChange(player.id, e)
+                        }
+                        displayEmpty
+                        aria-label={`${player.name}の打順`}
+                        sx={{ minHeight: 48 }}
+                      >
+                        <MenuItem value="">
+                          <em>未設定</em>
+                        </MenuItem>
+                        {orderOptions.map((order) => (
+                          <MenuItem key={order} value={order}>
+                            {order}番
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  )}
+                </Box>
+
+                <Box
+                  sx={{
+                    display: 'flex',
+                    gap: 1,
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  {onRegisterAtBat && (
+                    <Button
+                      id={registerAtBatButtonId(player.id)}
+                      variant="contained"
+                      onClick={() => onRegisterAtBat(player)}
+                      color="primary"
+                      startIcon={<AssignmentIcon />}
+                      sx={{ minHeight: 48, minWidth: 48, flex: 1 }}
+                    >
+                      打席登録
+                    </Button>
+                  )}
+                  {onToggleStatus && (
+                    <Button
+                      variant="outlined"
+                      onClick={() => onToggleStatus(player.id)}
+                      color="secondary"
+                      startIcon={<PersonOffIcon />}
+                      sx={{ minHeight: 48, minWidth: 48 }}
+                    >
+                      控えに
+                    </Button>
+                  )}
+                  {onEditPlayer && (
+                    <Tooltip title="選手情報を編集">
+                      <IconButton
+                        onClick={() => onEditPlayer(player.id)}
+                        aria-label="選手情報を編集"
+                        sx={{ minHeight: 48, minWidth: 48 }}
+                      >
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
+              </Paper>
+            );
+          })
+        ) : (
+          <Paper variant="outlined" sx={{ p: 2, mb: 1.5, textAlign: 'center' }}>
+            <Typography color="text.secondary">
+              出場中の選手がいません
+            </Typography>
+          </Paper>
+        )}
+
+        {/* 控えの選手セクション */}
+        {benchPlayers.length > 0 && (
+          <>
+            <Typography
+              variant="subtitle1"
+              sx={{
+                px: 2,
+                py: 1,
+                mt: 2,
+                mb: 1.5,
+                fontWeight: 'bold',
+                bgcolor: 'action.hover',
+                borderRadius: 1,
+              }}
+            >
+              控えの選手
+            </Typography>
+            {benchPlayers.map((player) => (
+              <Paper
+                key={player.id}
+                variant="outlined"
+                sx={{
+                  p: 2,
+                  mb: 1.5,
+                  bgcolor: 'action.hover',
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                    mb: 1.5,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    <Typography variant="subtitle1" fontWeight="bold">
+                      #{player.number} {player.name}
+                    </Typography>
+                    <Chip
+                      label={player.position}
+                      size="small"
+                      variant="filled"
+                    />
+                  </Box>
+
+                  {onUpdatePlayerOrder && (
+                    <FormControl size="small" sx={{ minWidth: 80 }}>
+                      <Select
+                        value={player.order === 0 ? '' : player.order}
+                        onChange={(e: SelectChangeEvent<number>) =>
+                          handleOrderChange(player.id, e)
+                        }
+                        displayEmpty
+                        aria-label={`${player.name}の打順`}
+                        sx={{ minHeight: 48 }}
+                      >
+                        <MenuItem value="">
+                          <em>未設定</em>
+                        </MenuItem>
+                        {orderOptions.map((order) => (
+                          <MenuItem key={order} value={order}>
+                            {order}番
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  )}
+                </Box>
+
+                <Box
+                  sx={{
+                    display: 'flex',
+                    gap: 1,
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  {onToggleStatus && (
+                    <Button
+                      variant="outlined"
+                      onClick={() => onToggleStatus(player.id)}
+                      color="success"
+                      startIcon={<PersonIcon />}
+                      sx={{ minHeight: 48, minWidth: 48, flex: 1 }}
+                    >
+                      出場させる
+                    </Button>
+                  )}
+                  {onEditPlayer && (
+                    <Tooltip title="選手情報を編集">
+                      <IconButton
+                        onClick={() => onEditPlayer(player.id)}
+                        aria-label="選手情報を編集"
+                        sx={{ minHeight: 48, minWidth: 48 }}
+                      >
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
+              </Paper>
+            ))}
+          </>
+        )}
+      </Box>
+    );
+  }
+
   return (
     <TableContainer component={Paper} sx={{ mb: 3 }}>
-      <Typography variant="h6" sx={{ p: 2 }}>
-        選手一覧
-      </Typography>
-
       {/* 出場中の選手 */}
       <Typography
         variant="subtitle1"
-        sx={{ px: 2, fontWeight: 'bold', bgcolor: 'action.hover' }}
+        sx={{ px: 2, py: 1, fontWeight: 'bold', bgcolor: 'action.hover' }}
       >
         出場中の選手
       </Typography>
@@ -91,9 +351,9 @@ const PlayerList: React.FC<PlayerListProps> = ({
         <TableHead>
           <TableRow>
             <TableCell>打順</TableCell>
-            <TableCell>{isMobile ? '番号' : '背番号'}</TableCell>
+            <TableCell>背番号</TableCell>
             <TableCell>名前</TableCell>
-            <TableCell>{isMobile ? 'ポジ' : 'ポジション'}</TableCell>
+            <TableCell>ポジション</TableCell>
             <TableCell>アクション</TableCell>
           </TableRow>
         </TableHead>
@@ -159,10 +419,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                         display: 'flex',
                         flexWrap: 'wrap',
                         gap: 0.5,
-                        '& .MuiButton-root': {
-                          minWidth: isMobile ? '36px' : '64px',
-                          padding: isMobile ? '4px 8px' : undefined,
-                        },
+                        alignItems: 'center',
                       }}
                     >
                       {onRegisterAtBat && (
@@ -172,13 +429,10 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           size="small"
                           onClick={() => onRegisterAtBat(player)}
                           color="primary"
-                          startIcon={
-                            isMobile ? (
-                              <AssignmentIcon fontSize="small" />
-                            ) : undefined
-                          }
+                          startIcon={<AssignmentIcon fontSize="small" />}
+                          sx={{ minHeight: 40 }}
                         >
-                          {isMobile ? '打席' : '打席登録'}
+                          打席登録
                         </Button>
                       )}
                       {onToggleStatus && (
@@ -187,13 +441,10 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           size="small"
                           onClick={() => onToggleStatus(player.id)}
                           color="secondary"
-                          startIcon={
-                            isMobile ? (
-                              <PersonOffIcon fontSize="small" />
-                            ) : undefined
-                          }
+                          startIcon={<PersonOffIcon fontSize="small" />}
+                          sx={{ minHeight: 40 }}
                         >
-                          {isMobile ? '控え' : '控えに'}
+                          控えに
                         </Button>
                       )}
                       {onEditPlayer && (
@@ -201,6 +452,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           <IconButton
                             size="small"
                             onClick={() => onEditPlayer(player.id)}
+                            aria-label="選手情報を編集"
                           >
                             <EditIcon fontSize="small" />
                           </IconButton>
@@ -228,6 +480,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
             variant="subtitle1"
             sx={{
               px: 2,
+              py: 1,
               mt: 2,
               fontWeight: 'bold',
               bgcolor: 'action.hover',
@@ -239,9 +492,9 @@ const PlayerList: React.FC<PlayerListProps> = ({
             <TableHead>
               <TableRow>
                 <TableCell>打順</TableCell>
-                <TableCell>{isMobile ? '番号' : '背番号'}</TableCell>
+                <TableCell>背番号</TableCell>
                 <TableCell>名前</TableCell>
-                <TableCell>{isMobile ? 'ポジ' : 'ポジション'}</TableCell>
+                <TableCell>ポジション</TableCell>
                 <TableCell>アクション</TableCell>
               </TableRow>
             </TableHead>
@@ -287,10 +540,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                         display: 'flex',
                         flexWrap: 'wrap',
                         gap: 0.5,
-                        '& .MuiButton-root': {
-                          minWidth: isMobile ? '36px' : '64px',
-                          padding: isMobile ? '4px 8px' : undefined,
-                        },
+                        alignItems: 'center',
                       }}
                     >
                       {onToggleStatus && (
@@ -299,13 +549,10 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           size="small"
                           onClick={() => onToggleStatus(player.id)}
                           color="success"
-                          startIcon={
-                            isMobile ? (
-                              <PersonIcon fontSize="small" />
-                            ) : undefined
-                          }
+                          startIcon={<PersonIcon fontSize="small" />}
+                          sx={{ minHeight: 40 }}
                         >
-                          {isMobile ? '出場' : '出場させる'}
+                          出場させる
                         </Button>
                       )}
                       {onEditPlayer && (
@@ -313,6 +560,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                           <IconButton
                             size="small"
                             onClick={() => onEditPlayer(player.id)}
+                            aria-label="選手情報を編集"
                           >
                             <EditIcon fontSize="small" />
                           </IconButton>

--- a/src/components/__tests__/PlayerList.test.tsx
+++ b/src/components/__tests__/PlayerList.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import PlayerList, { registerAtBatButtonId } from '../PlayerList';
 import { Player } from '../../types';

--- a/src/components/__tests__/PlayerList.test.tsx
+++ b/src/components/__tests__/PlayerList.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import PlayerList, { registerAtBatButtonId } from '../PlayerList';
+import { Player } from '../../types';
+
+const mockActivePlayers: Player[] = [
+  {
+    id: 'p1',
+    name: 'イチロー',
+    number: '51',
+    position: 'RF',
+    isActive: true,
+    order: 1,
+  },
+  {
+    id: 'p2',
+    name: '松井秀喜',
+    number: '55',
+    position: 'LF',
+    isActive: true,
+    order: 2,
+  },
+];
+
+const mockBenchPlayers: Player[] = [
+  {
+    id: 'p3',
+    name: '大谷翔平',
+    number: '17',
+    position: 'DH',
+    isActive: false,
+    order: 0,
+  },
+];
+
+const renderPlayerList = (
+  props?: Partial<React.ComponentProps<typeof PlayerList>>
+) => {
+  const theme = createTheme();
+  return render(
+    <ThemeProvider theme={theme}>
+      <PlayerList
+        players={[...mockActivePlayers, ...mockBenchPlayers]}
+        onRegisterAtBat={jest.fn()}
+        onToggleStatus={jest.fn()}
+        onEditPlayer={jest.fn()}
+        onUpdatePlayerOrder={jest.fn()}
+        nextBatterPlayerId="p1"
+        {...props}
+      />
+    </ThemeProvider>
+  );
+};
+
+describe('PlayerList component', () => {
+  test('「選手一覧」という重複見出しが表示されない', () => {
+    renderPlayerList();
+    // SectionCard 側で「選手一覧」見出しを持つため、PlayerList 内部には表示しない
+    expect(
+      screen.queryByRole('heading', { name: '選手一覧' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('出場中選手と控え選手が正しく分類され表示される', () => {
+    renderPlayerList();
+
+    expect(screen.getByText('出場中の選手')).toBeInTheDocument();
+    expect(screen.getByText('控えの選手')).toBeInTheDocument();
+    expect(screen.getByText('イチロー')).toBeInTheDocument();
+    expect(screen.getByText('松井秀喜')).toBeInTheDocument();
+    expect(screen.getByText('大谷翔平')).toBeInTheDocument();
+  });
+
+  test('次打者にバッジが表示され、打席登録ボタンに registerAtBatButtonId が設定される', () => {
+    renderPlayerList();
+
+    expect(screen.getByText('次打者')).toBeInTheDocument();
+    const registerButton = document.getElementById(registerAtBatButtonId('p1'));
+    expect(registerButton).toBeInTheDocument();
+  });
+
+  test('打席登録・ステータス切替・選手編集のハンドラーが正しく動作する', async () => {
+    const onRegisterAtBat = jest.fn();
+    const onToggleStatus = jest.fn();
+    const onEditPlayer = jest.fn();
+    const user = userEvent.setup();
+
+    renderPlayerList({
+      onRegisterAtBat,
+      onToggleStatus,
+      onEditPlayer,
+    });
+
+    const registerButton = document.getElementById(registerAtBatButtonId('p1'));
+    if (registerButton) {
+      await user.click(registerButton);
+      expect(onRegisterAtBat).toHaveBeenCalledWith(mockActivePlayers[0]);
+    }
+
+    const benchButtons = screen.getAllByRole('button', { name: /控え/ });
+    await user.click(benchButtons[0]);
+    expect(onToggleStatus).toHaveBeenCalledWith('p1');
+
+    const editButtons = screen.getAllByRole('button', {
+      name: '選手情報を編集',
+    });
+    await user.click(editButtons[0]);
+    expect(onEditPlayer).toHaveBeenCalledWith('p1');
+  });
+
+  test('出場中の選手が0人のときはメッセージを表示する', () => {
+    renderPlayerList({ players: mockBenchPlayers });
+
+    expect(screen.getByText('出場中の選手がいません')).toBeInTheDocument();
+  });
+});
+
+describe('PlayerList mobile card view', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('モバイル表示時はテーブルではなくカード形式で表示され、省略語を使わない', () => {
+    renderPlayerList();
+
+    // 5列テーブル（table要素）が存在しないこと
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+
+    // カードレイアウトで選手情報が表示されること
+    expect(screen.getByText('#51 イチロー')).toBeInTheDocument();
+    expect(screen.getByText('#55 松井秀喜')).toBeInTheDocument();
+    expect(screen.getByText('#17 大谷翔平')).toBeInTheDocument();
+
+    // 省略語ではなく正式名称のボタンが表示されること
+    const registerButtons = screen.getAllByRole('button', { name: /打席登録/ });
+    expect(registerButtons.length).toBe(2);
+
+    const benchButtons = screen.getAllByRole('button', { name: /控えに/ });
+    expect(benchButtons.length).toBe(2);
+
+    const playButtons = screen.getAllByRole('button', { name: /出場させる/ });
+    expect(playButtons.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #235 に対応し、モバイル環境における選手一覧のカードレイアウト化、見出し重複の解消、48px タッチターゲットの確保、および Snackbar の親指リーチ可能な下部配置を実施しました。

## 変更内容
- **PlayerList**:
  - `sm` 未満（モバイル）において、狭い5列テーブルと略語ラベル（番号/ポジ/打席/控え）を廃止し、1選手1カードのモバイル専用カードレイアウトを導入
  - モバイルの全タップターゲット（打順選択 Select, 打席登録 Button, 控えに Button, 出場させる Button, 編集 IconButton）の最小サイズを 48px 以上（`minHeight: 48, minWidth: 48`）に設定
  - `SectionCard` との重複となっていた内部の「選手一覧」見出し（`<Typography variant="h6">選手一覧</Typography>`）を削除
  - `renderOrderControl` / `renderEditButton` レンダーヘルパー関数を抽出して重複コードを整理し、`onUpdatePlayerOrder` 未指定時のフォールバック表示を提供
- **MainApp**:
  - モバイル時に `Snackbar` の `anchorOrigin` を `{ vertical: 'bottom', horizontal: 'center' }` に設定し、sticky な AppBar との干渉を回避して親指で操作しやすい位置に調整
- **テスト**:
  - `src/components/__tests__/PlayerList.test.tsx` を新規追加し、重複見出し非存在、出場/控え分類、次打者バッジ、ハンドラー実行、およびモバイルカード表示のテストを実装

## 発見・起票した関連 Issue
- #261: ScoreBoard: Typography コンポーネントに sx ではなく fontWeight prop が直接渡されている

## 実行したテスト
- `npm run ci:local` (全 36 スイート 227 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (全指摘事項を反映済み)

Closes #235
