### PR TITLE
fix: AtBatSummaryTable の TableCell に key prop を付与し React 警告を解消

### DIFF
--- a/src/components/AtBatSummaryTable.tsx
+++ b/src/components/AtBatSummaryTable.tsx
@@ -210,13 +210,17 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
   };
 
   // 打席結果を表示するセル（複数の結果に対応）
-  const renderAtBatCell = (atBats: AtBat[]) => {
+  const renderAtBatCell = (atBats: AtBat[], key?: string | number) => {
     if (!atBats.length) {
-      return <TableCell align="center">-</TableCell>;
+      return (
+        <TableCell key={key} align="center">
+          -
+        </TableCell>
+      );
     }
 
     return (
-      <TableCell align="center">
+      <TableCell key={key} align="center">
         <Stack
           direction="row"
           spacing={0.5}
@@ -629,8 +633,12 @@ const AtBatSummaryTable: React.FC<AtBatSummaryTableProps> = ({
                     </Typography>
                   </TableCell>
                   {innings.map((inning) =>
-                    renderAtBatCell(getPlayerAtBatsForInning(player.id, inning))
+                    renderAtBatCell(
+                      getPlayerAtBatsForInning(player.id, inning),
+                      inning
+                    )
                   )}
+
                   <TableCell align="center">{stats.atBats}</TableCell>
                   <TableCell align="center">{stats.hits}</TableCell>
                   <TableCell align="center">{stats.rbis}</TableCell>

--- a/src/components/__tests__/AtBatSummaryTable.test.tsx
+++ b/src/components/__tests__/AtBatSummaryTable.test.tsx
@@ -95,4 +95,18 @@ describe('AtBatSummaryTable', () => {
     expect(backgroundColor).not.toBe('rgb(248, 248, 248)');
     expect(backgroundColor).toContain('rgba(255, 255, 255');
   });
+
+  test('各イニングの TableCell に unique な key が付与されており React warning が出ない', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTable(true);
+    const keyWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some(
+        (arg) =>
+          typeof arg === 'string' &&
+          arg.includes('Each child in a list should have a unique "key" prop')
+      )
+    );
+    expect(keyWarnings).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## 概要
Issue #255 に対応し、`AtBatSummaryTable` のイニング別打席結果セル描画において `TableCell` に `key` prop が欠落していた問題を修正しました。

## 変更内容
- **AtBatSummaryTable.tsx**:
  - `renderAtBatCell` に `key` 引数を追加し、返却する `<TableCell>` 要素（結果あり・空セルの双方）に `key={key}` を設定
  - デスクトップ表示のイニングマッピング部で `renderAtBatCell(..., inning)` を渡すよう更新
- **AtBatSummaryTable.test.tsx**:
  - レンダリング時に React の `Each child in a list should have a unique "key" prop` 警告が出ないことを検証するテストを追加

## 実行したテスト
- `npm run ci:local` (全 35 スイート 222 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (0 指摘)

Closes #255
