### PR TITLE
fix: ScoreBoard の Typography に sx prop 経由で fontWeight を指定

### DIFF
--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -124,10 +124,11 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
           id={headingId}
           component="h2"
           variant="subtitle1"
-          fontWeight={600}
+          sx={{ fontWeight: 600 }}
         >
           スコアボード
         </Typography>
+
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={2}
@@ -154,7 +155,7 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                 <Typography variant="body2" color="text.secondary">
                   {team.name}
                 </Typography>
-                <Typography variant="body2" fontWeight={600}>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
                   R {summary.runs} / H {summary.hits} / E {summary.errors}
                 </Typography>
               </Box>
@@ -282,8 +283,10 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
               >
                 <Typography
                   variant="body2"
-                  fontWeight="bold"
-                  sx={{ fontSize: isMobile ? '0.8rem' : '0.875rem' }}
+                  sx={{
+                    fontWeight: 'bold',
+                    fontSize: isMobile ? '0.8rem' : '0.875rem',
+                  }}
                 >
                   {awayTeam.name}
                 </Typography>
@@ -339,8 +342,10 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
               >
                 <Typography
                   variant="body2"
-                  fontWeight="bold"
-                  sx={{ fontSize: isMobile ? '0.8rem' : '0.875rem' }}
+                  sx={{
+                    fontWeight: 'bold',
+                    fontSize: isMobile ? '0.8rem' : '0.875rem',
+                  }}
                 >
                   {homeTeam.name}
                 </Typography>

--- a/src/components/__tests__/ScoreBoard.a11y.test.tsx
+++ b/src/components/__tests__/ScoreBoard.a11y.test.tsx
@@ -153,4 +153,25 @@ describe('ScoreBoard accessibility', () => {
 
     expect(homeSummary).toHaveTextContent(/R 3 \/ H 1 \/ E 1/);
   });
+
+  test('TypographyコンポーネントにfontWeightがsx経由で正しく適用されReactのDOM警告が出ない', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderScoreBoard();
+
+    const heading = screen.getByText('スコアボード');
+    expect(heading).toBeInTheDocument();
+    expect(getComputedStyle(heading).fontWeight).toBe('600');
+
+    const domWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some(
+        (arg) =>
+          typeof arg === 'string' &&
+          arg.includes(
+            'React does not recognize the `fontWeight` prop on a DOM element'
+          )
+      )
+    );
+    expect(domWarnings).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## 概要
Issue #261 に対応し、`ScoreBoard.tsx` において `<Typography>` に直接渡されていた `fontWeight` prop を `sx={{ fontWeight: ... }}` に修正しました。

## 変更内容
- **ScoreBoard.tsx**:
  - 見出し、チームサマリー（R/H/E）、および各チーム名行の `<Typography>` で `fontWeight` を `sx` prop 経由で適用
- **ScoreBoard.a11y.test.tsx**:
  - `Typography` の `fontWeight` が正しく適用され、React の DOM 属性警告が発生しないことを検証するテストを追加

## 実行したテスト
- `npm run ci:local` (全 35 スイート 222 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (0 指摘)

Closes #261
