### PR TITLE
feat(routing): 画面遷移のURL化（3つのbooleanフラグ統合とsetTimeoutハックの除去）

### DIFF
--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { render, screen, within, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import MainApp from './MainApp';
 
@@ -26,9 +27,26 @@ jest.mock('./firebase/teamService', () => ({
   getUserTeams: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('./firebase/statsService', () => ({
+  getAllTeamStats: jest.fn().mockResolvedValue([]),
+  getPlayerStats: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('./firebase/authService', () => ({
+  auth: { currentUser: { uid: 'test-user', email: 'test@example.com' } },
+  googleProvider: {},
+  signInWithGoogle: jest.fn(),
+  logout: jest.fn(),
+  onAuthStateChangedListener: jest.fn((callback) => {
+    callback({ uid: 'test-user', email: 'test@example.com' });
+    return jest.fn();
+  }),
+}));
+
 jest.mock('./firebase/analyticsClient', () => ({
   logAnalyticsEvent: jest.fn(),
 }));
+
 
 const renderMainApp = () =>
   render(
@@ -320,5 +338,105 @@ describe('MainApp - 表示モード切替', () => {
       mode: 'edit',
     });
     expect(screen.getByText('1回の操作')).toBeInTheDocument();
+  });
+});
+
+describe('MainApp - URL駆動の画面遷移', () => {
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  test('メニューから「試合一覧を表示」に遷移するとURLが更新され、戻るボタンで試合画面に復帰できる', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    // メニューを開く
+    await openMenu(user);
+
+    // 「試合一覧を表示」をクリック
+    const gameListMenuItem = await screen.findByText('試合一覧を表示');
+    await user.click(gameListMenuItem);
+
+    // URLのクエリパラメータが ?view=gameList になっていること
+    expect(window.location.search).toContain('view=gameList');
+
+    // ヘッダーに「試合画面に戻る」ボタンが表示されること
+    const backButton = await screen.findByRole('button', {
+      name: '試合画面に戻る',
+    });
+    expect(backButton).toBeInTheDocument();
+
+    // 戻るボタンをクリック
+    await user.click(backButton);
+
+    // URLが試合画面（クエリなし）に戻り、1回の操作が表示されること
+    expect(window.location.search).not.toContain('view=gameList');
+    expect(await screen.findByText('1回の操作')).toBeInTheDocument();
+  }, 15000);
+
+  test('ブラウザの戻る進む操作（popstate）で画面状態が同期する', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    await openMenu(user);
+    const gameListMenuItem = await screen.findByText('試合一覧を表示');
+    await user.click(gameListMenuItem);
+
+    expect(window.location.search).toContain('view=gameList');
+
+    // popstate イベントを発火（試合画面に戻る）
+    window.history.pushState({}, '', '/');
+    await act(async () => {
+      window.dispatchEvent(
+        new PopStateEvent('popstate', { state: { view: 'game' } })
+      );
+    });
+
+    expect(await screen.findByText('1回の操作')).toBeInTheDocument();
+  }, 15000);
+
+  test('メニューから「チーム・選手管理」および「通算成績」への遷移でURLが正しく更新される', async () => {
+    const user = userEvent.setup();
+    renderMainApp();
+
+    // チーム・選手管理へ遷移
+    await openMenu(user);
+    const teamMenuItem = await screen.findByText('チーム・選手管理');
+    await user.click(teamMenuItem);
+
+    expect(window.location.search).toContain('view=teamManagement');
+
+    // 戻るボタンで復帰
+    const backButton1 = await screen.findByRole('button', {
+      name: '試合画面に戻る',
+    });
+    await user.click(backButton1);
+    expect(window.location.search).not.toContain('view=teamManagement');
+
+    // 通算成績へ遷移
+    await openMenu(user);
+    const statsMenuItem = await screen.findByText('通算成績');
+    await user.click(statsMenuItem);
+
+    expect(window.location.search).toContain('view=teamStats');
+
+    // 戻るボタンで復帰
+    const backButton2 = await screen.findByRole('button', {
+      name: '試合画面に戻る',
+    });
+    await user.click(backButton2);
+    expect(window.location.search).not.toContain('view=teamStats');
+  }, 15000);
+
+  test('URLパラメータ ?view=teamStats で初期表示した場合は通算成績画面がレンダリングされる', async () => {
+    window.history.replaceState({}, '', '/?view=teamStats');
+    renderMainApp();
+
+    const backButton = await screen.findByRole('button', {
+      name: '試合画面に戻る',
+    });
+    expect(backButton).toBeInTheDocument();
+    expect(screen.queryByText('1回の操作')).not.toBeInTheDocument();
   }, 15000);
 });
+

--- a/src/MainApp.test.tsx
+++ b/src/MainApp.test.tsx
@@ -47,7 +47,6 @@ jest.mock('./firebase/analyticsClient', () => ({
   logAnalyticsEvent: jest.fn(),
 }));
 
-
 const renderMainApp = () =>
   render(
     <ThemeProvider theme={createTheme()}>
@@ -439,4 +438,3 @@ describe('MainApp - URL駆動の画面遷移', () => {
     expect(screen.queryByText('1回の操作')).not.toBeInTheDocument();
   }, 15000);
 });
-

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -4,9 +4,11 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useCallback,
   lazy,
   Suspense,
 } from 'react';
+
 import {
   Container,
   AppBar,
@@ -121,12 +123,28 @@ const sendAnalyticsEvent = (
 };
 
 // アプリのメインコンテンツコンポーネント
+export type AppView = 'game' | 'gameList' | 'teamManagement' | 'teamStats';
+
+const getViewFromUrl = (): AppView => {
+  if (typeof window === 'undefined') return 'game';
+  const params = new URLSearchParams(window.location.search);
+  const view = params.get('view');
+  if (
+    view === 'gameList' ||
+    view === 'teamManagement' ||
+    view === 'teamStats'
+  ) {
+    return view;
+  }
+  return 'game';
+};
+
 const MainApp: React.FC<{
   toggleColorMode: () => void;
   mode: PaletteMode;
 }> = ({ toggleColorMode, mode }) => {
-  const { currentUser, isLoading } = useAuth();
   const theme = useTheme();
+  const { currentUser, isLoading } = useAuth();
   const initialGame = useMemo(() => createInitialGame(), []);
   const {
     state: gameState,
@@ -140,8 +158,31 @@ const MainApp: React.FC<{
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [activeStep, setActiveStep] = useState(0);
 
+  // 画面遷移状態（URLクエリパラメータ ?view=... と同期）
+  const [currentView, setCurrentView] = useState<AppView>(getViewFromUrl);
+
+  const navigateToView = useCallback((nextView: AppView) => {
+    setCurrentView(nextView);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (nextView === 'game') {
+        url.searchParams.delete('view');
+      } else {
+        url.searchParams.set('view', nextView);
+      }
+      window.history.pushState({ view: nextView }, '', url.toString());
+    }
+  }, []);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setCurrentView(getViewFromUrl());
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
   // 試合保存・読み込み関連の状態
-  const [showGameList, setShowGameList] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -149,12 +190,6 @@ const MainApp: React.FC<{
   const [snackbarSeverity, setSnackbarSeverity] = useState<
     'success' | 'error' | 'info' | 'warning'
   >('success');
-
-  // チーム管理関連の状態
-  const [showTeamManagement, setShowTeamManagement] = useState(false);
-
-  // 通算成績関連の状態
-  const [showTeamStats, setShowTeamStats] = useState(false);
 
   // メニュー関連の状態
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
@@ -216,15 +251,14 @@ const MainApp: React.FC<{
   const isSmallMobile = useMediaQuery('(max-width:380px)');
 
   // 画面モードの判定
-  const isGameInputMode =
-    !showGameList && !showTeamManagement && !showTeamStats;
+  const isGameInputMode = currentView === 'game';
 
   // 動的タイトルの取得
   const getPageTitle = (): string => {
     if (isSharedMode) return '野球スコア（閲覧専用）';
-    if (showGameList) return '試合一覧';
-    if (showTeamManagement) return '選手管理';
-    if (showTeamStats) return '通算成績';
+    if (currentView === 'gameList') return '試合一覧';
+    if (currentView === 'teamManagement') return '選手管理';
+    if (currentView === 'teamStats') return '通算成績';
     return '野球スコア';
   };
 
@@ -520,39 +554,21 @@ const MainApp: React.FC<{
 
   // 試合一覧の表示/非表示切り替え
   const toggleGameList = () => {
-    setShowGameList(!showGameList);
-
-    // 他の画面を非表示にする
-    if (showTeamManagement) {
-      setShowTeamManagement(false);
-    }
-
-    // 通算成績画面が表示されている場合は閉じる
-    if (showTeamStats) {
-      setShowTeamStats(false);
-    }
-
+    navigateToView(currentView === 'gameList' ? 'game' : 'gameList');
     handleMenuClose();
   };
 
   // チーム管理画面の表示/非表示切り替え
   const toggleTeamManagement = () => {
-    // 他の画面を閉じる
-    setShowGameList(false);
-    setShowTeamStats(false);
-    // 遅延を追加してレンダリングの問題を回避
-    setTimeout(() => {
-      setShowTeamManagement(!showTeamManagement);
-    }, 10);
+    navigateToView(
+      currentView === 'teamManagement' ? 'game' : 'teamManagement'
+    );
     handleMenuClose();
   };
 
   // 通算成績画面の表示/非表示切り替え
   const toggleTeamStats = () => {
-    setShowTeamStats(!showTeamStats);
-    // 他の画面を非表示にする
-    setShowGameList(false);
-    setShowTeamManagement(false);
+    navigateToView(currentView === 'teamStats' ? 'game' : 'teamStats');
     handleMenuClose();
   };
 
@@ -568,9 +584,7 @@ const MainApp: React.FC<{
 
   // 試合画面に戻る
   const handleBackToGame = () => {
-    if (showGameList) setShowGameList(false);
-    if (showTeamManagement) setShowTeamManagement(false);
-    if (showTeamStats) setShowTeamStats(false);
+    navigateToView('game');
     handleMenuClose();
   };
 
@@ -579,17 +593,8 @@ const MainApp: React.FC<{
     pendingBaselineResetRef.current = true;
     gameActions.resetGame();
     handleMenuClose();
-    // 試合一覧画面が表示されている場合は閉じる
-    if (showGameList) {
-      setShowGameList(false);
-    }
-    // チーム管理画面が表示されている場合は閉じる
-    if (showTeamManagement) {
-      setShowTeamManagement(false);
-    }
-    // 通算成績画面が表示されている場合は閉じる
-    if (showTeamStats) {
-      setShowTeamStats(false);
+    if (currentView !== 'game') {
+      navigateToView('game');
     }
   };
 
@@ -747,9 +752,10 @@ const MainApp: React.FC<{
         setSnackbarMessage('試合データを読み込みました');
         setSnackbarSeverity('success');
         setSnackbarOpen(true);
-        setShowGameList(false);
+        navigateToView('game');
 
         // アナリティクスイベント：試合データ読み込み
+
         sendAnalyticsEvent('game_load', {
           gameId,
           teams: `${loadedGame.awayTeam.name} vs ${loadedGame.homeTeam.name}`,
@@ -1125,8 +1131,7 @@ const MainApp: React.FC<{
       )}
 
       <Container sx={{ pt: 2 }}>
-        {/* 画面の優先順位: チーム管理画面 > 通算成績 > ゲーム一覧 > 通常の試合画面 */}
-        {showTeamManagement && !isSharedMode ? (
+        {currentView === 'teamManagement' && !isSharedMode ? (
           <Suspense
             fallback={
               <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
@@ -1136,7 +1141,7 @@ const MainApp: React.FC<{
           >
             <TeamList />
           </Suspense>
-        ) : showTeamStats && !isSharedMode ? (
+        ) : currentView === 'teamStats' && !isSharedMode ? (
           <Suspense
             fallback={
               <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
@@ -1146,7 +1151,7 @@ const MainApp: React.FC<{
           >
             <TeamStatsList />
           </Suspense>
-        ) : showGameList && !isSharedMode ? (
+        ) : currentView === 'gameList' && !isSharedMode ? (
           <Suspense
             fallback={
               <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -123,12 +123,13 @@ const sendAnalyticsEvent = (
 };
 
 // アプリのメインコンテンツコンポーネント
-export type AppView = 'game' | 'gameList' | 'teamManagement' | 'teamStats';
+const VIEW_PARAM = 'view';
+type AppView = 'game' | 'gameList' | 'teamManagement' | 'teamStats';
 
 const getViewFromUrl = (): AppView => {
   if (typeof window === 'undefined') return 'game';
   const params = new URLSearchParams(window.location.search);
-  const view = params.get('view');
+  const view = params.get(VIEW_PARAM);
   if (
     view === 'gameList' ||
     view === 'teamManagement' ||
@@ -161,28 +162,46 @@ const MainApp: React.FC<{
   // 画面遷移状態（URLクエリパラメータ ?view=... と同期）
   const [currentView, setCurrentView] = useState<AppView>(getViewFromUrl);
 
-  const navigateToView = useCallback((nextView: AppView) => {
-    setCurrentView(nextView);
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href);
-      if (nextView === 'game') {
-        url.searchParams.delete('view');
-      } else {
-        url.searchParams.set('view', nextView);
+  const navigateToView = useCallback(
+    (nextView: AppView, replace = false) => {
+      setCurrentView(nextView);
+      if (typeof window !== 'undefined') {
+        const url = new URL(window.location.href);
+        if (nextView === 'game') {
+          url.searchParams.delete(VIEW_PARAM);
+        } else {
+          url.searchParams.set(VIEW_PARAM, nextView);
+        }
+        const method =
+          replace || (nextView === 'game' && currentView !== 'game')
+            ? 'replaceState'
+            : 'pushState';
+        window.history[method]({ view: nextView }, '', url.toString());
       }
-      window.history.pushState({ view: nextView }, '', url.toString());
-    }
-  }, []);
+    },
+    [currentView]
+  );
 
   useEffect(() => {
-    const handlePopState = () => {
-      setCurrentView(getViewFromUrl());
+    const handlePopState = (event: PopStateEvent) => {
+      const stateView = (event.state as { view?: AppView } | null)?.view;
+      if (
+        stateView === 'game' ||
+        stateView === 'gameList' ||
+        stateView === 'teamManagement' ||
+        stateView === 'teamStats'
+      ) {
+        setCurrentView(stateView);
+      } else {
+        setCurrentView(getViewFromUrl());
+      }
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);
 
   // 試合保存・読み込み関連の状態
+
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -249,6 +268,13 @@ const MainApp: React.FC<{
   // レスポンシブデザイン用のメディアクエリ
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isSmallMobile = useMediaQuery('(max-width:380px)');
+
+  // 非同期コンポーネント用フォールバック
+  const viewFallback = (
+    <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+      <CircularProgress />
+    </Box>
+  );
 
   // 画面モードの判定
   const isGameInputMode = currentView === 'game';
@@ -552,25 +578,15 @@ const MainApp: React.FC<{
     setSelectedPlayer(null);
   };
 
-  // 試合一覧の表示/非表示切り替え
-  const toggleGameList = () => {
-    navigateToView(currentView === 'gameList' ? 'game' : 'gameList');
+  // 画面の表示/非表示切り替えヘルパー
+  const toggleView = (view: Exclude<AppView, 'game'>) => {
+    navigateToView(currentView === view ? 'game' : view);
     handleMenuClose();
   };
 
-  // チーム管理画面の表示/非表示切り替え
-  const toggleTeamManagement = () => {
-    navigateToView(
-      currentView === 'teamManagement' ? 'game' : 'teamManagement'
-    );
-    handleMenuClose();
-  };
-
-  // 通算成績画面の表示/非表示切り替え
-  const toggleTeamStats = () => {
-    navigateToView(currentView === 'teamStats' ? 'game' : 'teamStats');
-    handleMenuClose();
-  };
+  const toggleGameList = () => toggleView('gameList');
+  const toggleTeamManagement = () => toggleView('teamManagement');
+  const toggleTeamStats = () => toggleView('teamStats');
 
   // メニューを開く
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -755,7 +771,6 @@ const MainApp: React.FC<{
         navigateToView('game');
 
         // アナリティクスイベント：試合データ読み込み
-
         sendAnalyticsEvent('game_load', {
           gameId,
           teams: `${loadedGame.awayTeam.name} vs ${loadedGame.homeTeam.name}`,
@@ -1132,33 +1147,15 @@ const MainApp: React.FC<{
 
       <Container sx={{ pt: 2 }}>
         {currentView === 'teamManagement' && !isSharedMode ? (
-          <Suspense
-            fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                <CircularProgress />
-              </Box>
-            }
-          >
+          <Suspense fallback={viewFallback}>
             <TeamList />
           </Suspense>
         ) : currentView === 'teamStats' && !isSharedMode ? (
-          <Suspense
-            fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                <CircularProgress />
-              </Box>
-            }
-          >
+          <Suspense fallback={viewFallback}>
             <TeamStatsList />
           </Suspense>
         ) : currentView === 'gameList' && !isSharedMode ? (
-          <Suspense
-            fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                <CircularProgress />
-              </Box>
-            }
-          >
+          <Suspense fallback={viewFallback}>
             <GameList
               onSelectGame={handleSelectGame}
               onGameDeleted={() => {

--- a/src/components/TeamStatsList.tsx
+++ b/src/components/TeamStatsList.tsx
@@ -177,10 +177,11 @@ const TeamStatsList: React.FC = () => {
         const stats = await getAllTeamStats();
         if (cancelled) return;
 
-        setTeamStats(stats);
+        const safeStats = Array.isArray(stats) ? stats : [];
+        setTeamStats(safeStats);
         // 最初のチームが選択された状態にする
-        if (stats.length > 0) {
-          setSelectedTeamId(stats[0].teamId);
+        if (safeStats.length > 0) {
+          setSelectedTeamId(safeStats[0].teamId);
         }
       } catch (err: unknown) {
         if (cancelled) return;
@@ -206,7 +207,7 @@ const TeamStatsList: React.FC = () => {
 
   // 選択中のチーム（一覧が変化しても存在しないIDを指し続けない）
   const selectedTeam =
-    teamStats.find((team) => team.teamId === selectedTeamId) ?? null;
+    teamStats?.find((team) => team.teamId === selectedTeamId) ?? null;
 
   if (loading) {
     return (


### PR DESCRIPTION
## 概要
Issue #232 に対応し、`MainApp` における画面状態管理を 3つの boolean state（`showGameList`, `showTeamManagement`, `showTeamStats`）から単一の union 型 `AppView`（`'game' | 'gameList' | 'teamManagement' | 'teamStats'`）および URL クエリパラメータ（`?view=...`）駆動へと統合・移行しました。
これにより、`popstate` ハンドラ内の `setTimeout` ハックやレンダリング遅延ハック、画面相互排他制御のボイラープレートを完全に排除し、ブラウザの「戻る / 進む」や URL 直リンクで正しく画面遷移できるように改善しました。

## 変更内容
- **MainApp.tsx**:
  - `type AppView = 'game' | 'gameList' | 'teamManagement' | 'teamStats'` を定義
  - 3つの boolean state を単一の `currentView` state に統合し、URL クエリパラメータ `?view=...` と同期
  - `navigateToView` および `popstate` イベントリスナーで History API（`pushState` / `replaceState` / `popstate`）と状態を同期
  - `toggleView` ヘルパーを抽出してメニュー切り替えコードの重複を解消
  - `setTimeout` 遅延ハックの完全除去
  - `Suspense` の共通フォールバック `viewFallback` を抽出
- **MainApp.test.tsx**:
  - メニューからの画面遷移と URL クエリパラメータ更新・戻るボタン復帰のテスト
  - `popstate` イベントによるブラウザ履歴同期のテスト
  - 各メニュー項目（チーム・選手管理、通算成績）への遷移テスト
  - URL クエリパラメータ `?view=teamStats` 直アクセス時の初期レンダリングテスト

## 実行したテスト
- `npm run ci:local` (全 35 スイート 225 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (全 5 件のレビュー指摘を反映済み)

Closes #232
