### PR TITLE
feat(ui): スコアボードに R/H/E 列を追加し表外サマリーを統合

### DIFF
--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useId } from 'react';
 import {
-  Box,
   Paper,
   Table,
   TableBody,
@@ -10,8 +9,8 @@ import {
   TableRow,
   Typography,
   useMediaQuery,
-  Stack,
 } from '@mui/material';
+
 import { alpha, useTheme } from '@mui/material/styles';
 import { Team, RunEvent } from '../types';
 import { ScoreCalculator } from '../services/ScoreCalculator';
@@ -91,11 +90,6 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
     [awayTeam, homeTeam, totalScores]
   );
 
-  const teamSummaries: Array<{ team: Team; key: 'home' | 'away' }> = [
-    { team: awayTeam, key: 'away' },
-    { team: homeTeam, key: 'home' },
-  ];
-
   const highlightStyles = {
     backgroundColor: alpha(theme.palette.primary.main, 0.12),
     borderLeft: `2px solid ${theme.palette.primary.main}`,
@@ -114,55 +108,15 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
       aria-labelledby={headingId}
       sx={{ mb: 3, mt: 3, p: { xs: 2, sm: 3 } }}
     >
-      <Stack
-        direction={{ xs: 'column', md: 'row' }}
-        justifyContent="space-between"
-        alignItems={{ xs: 'flex-start', md: 'center' }}
-        spacing={2}
+      <Typography
+        id={headingId}
+        component="h2"
+        variant="subtitle1"
+        sx={{ fontWeight: 600, mb: 1 }}
       >
-        <Typography
-          id={headingId}
-          component="h2"
-          variant="subtitle1"
-          sx={{ fontWeight: 600 }}
-        >
-          スコアボード
-        </Typography>
+        スコアボード
+      </Typography>
 
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          spacing={2}
-          sx={{
-            width: '100%',
-            justifyContent: { xs: 'flex-start', md: 'flex-end' },
-          }}
-        >
-          {teamSummaries.map(({ team, key }) => {
-            const summary = summaryData[key];
-            return (
-              <Box
-                key={key}
-                data-testid={`scoreboard-summary-${key}`}
-                sx={{
-                  flex: 1,
-                  minWidth: 160,
-                  border: `1px solid ${theme.palette.divider}`,
-                  borderRadius: 1,
-                  p: 1.5,
-                  fontVariantNumeric: 'tabular-nums',
-                }}
-              >
-                <Typography variant="body2" color="text.secondary">
-                  {team.name}
-                </Typography>
-                <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                  R {summary.runs} / H {summary.hits} / E {summary.errors}
-                </Typography>
-              </Box>
-            );
-          })}
-        </Stack>
-      </Stack>
 
       <TableContainer
         ref={containerRef}
@@ -201,7 +155,7 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
           size={isMobile ? 'small' : 'medium'}
           sx={{
             minWidth: isMobile ? 300 : 'auto',
-            mt: 2,
+            mt: 1,
             '& .MuiTableCell-root': {
               fontSize: isMobile ? '0.8rem' : '0.875rem',
               padding: isMobile ? '6px 8px' : '8px 16px',
@@ -251,14 +205,36 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                 title="合計得点"
                 sx={{
                   fontWeight: 'bold',
-                  minWidth: isMobile ? '40px' : '50px',
-                  position: 'sticky',
-                  right: 0,
-                  backgroundColor: theme.palette.background.paper,
-                  zIndex: 2,
+                  minWidth: isMobile ? '32px' : '40px',
                 }}
               >
                 R
+              </TableCell>
+              <TableCell
+                component="th"
+                scope="col"
+                align="right"
+                aria-label="安打数"
+                title="安打数"
+                sx={{
+                  fontWeight: 'bold',
+                  minWidth: isMobile ? '32px' : '40px',
+                }}
+              >
+                H
+              </TableCell>
+              <TableCell
+                component="th"
+                scope="col"
+                align="right"
+                aria-label="失策数"
+                title="失策数"
+                sx={{
+                  fontWeight: 'bold',
+                  minWidth: isMobile ? '32px' : '40px',
+                }}
+              >
+                E
               </TableCell>
             </TableRow>
           </TableHead>
@@ -310,15 +286,24 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
               ))}
               <TableCell
                 align="right"
-                sx={{
-                  fontWeight: 'bold',
-                  position: 'sticky',
-                  right: 0,
-                  backgroundColor: theme.palette.background.paper,
-                  zIndex: 1,
-                }}
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-r-away"
               >
-                {totalScores.away}
+                {summaryData.away.runs}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-h-away"
+              >
+                {summaryData.away.hits}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-e-away"
+              >
+                {summaryData.away.errors}
               </TableCell>
             </TableRow>
 
@@ -369,15 +354,24 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
               ))}
               <TableCell
                 align="right"
-                sx={{
-                  fontWeight: 'bold',
-                  position: 'sticky',
-                  right: 0,
-                  backgroundColor: theme.palette.background.paper,
-                  zIndex: 1,
-                }}
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-r-home"
               >
-                {totalScores.home}
+                {summaryData.home.runs}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-h-home"
+              >
+                {summaryData.home.hits}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 'bold' }}
+                data-testid="scoreboard-e-home"
+              >
+                {summaryData.home.errors}
               </TableCell>
             </TableRow>
           </TableBody>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -129,7 +129,6 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
         スコアボード
       </Typography>
 
-
       <TableContainer
         ref={containerRef}
         sx={{

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -21,6 +21,18 @@ const countHits = (team: Team): number =>
 const countErrors = (team: Team): number =>
   ScoreCalculator.calculateErrors(team.atBats);
 
+const SUMMARY_COLUMNS = [
+  { key: 'runs', label: 'R', ariaLabel: '合計得点' },
+  { key: 'hits', label: 'H', ariaLabel: '安打数' },
+  { key: 'errors', label: 'E', ariaLabel: '失策数' },
+] as const;
+
+const getSummaryColumnRightOffset = (index: number, isMobile: boolean) => {
+  const colWidth = isMobile ? 32 : 40;
+  const fromRight = SUMMARY_COLUMNS.length - 1 - index;
+  return fromRight * colWidth;
+};
+
 interface ScoreBoardProps {
   homeTeam: Team;
   awayTeam: Team;
@@ -197,45 +209,26 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                   {inning}
                 </TableCell>
               ))}
-              <TableCell
-                component="th"
-                scope="col"
-                align="right"
-                aria-label="合計得点"
-                title="合計得点"
-                sx={{
-                  fontWeight: 'bold',
-                  minWidth: isMobile ? '32px' : '40px',
-                }}
-              >
-                R
-              </TableCell>
-              <TableCell
-                component="th"
-                scope="col"
-                align="right"
-                aria-label="安打数"
-                title="安打数"
-                sx={{
-                  fontWeight: 'bold',
-                  minWidth: isMobile ? '32px' : '40px',
-                }}
-              >
-                H
-              </TableCell>
-              <TableCell
-                component="th"
-                scope="col"
-                align="right"
-                aria-label="失策数"
-                title="失策数"
-                sx={{
-                  fontWeight: 'bold',
-                  minWidth: isMobile ? '32px' : '40px',
-                }}
-              >
-                E
-              </TableCell>
+              {SUMMARY_COLUMNS.map((col, idx) => (
+                <TableCell
+                  key={col.key}
+                  component="th"
+                  scope="col"
+                  align="right"
+                  aria-label={col.ariaLabel}
+                  title={col.ariaLabel}
+                  sx={{
+                    fontWeight: 'bold',
+                    minWidth: isMobile ? '32px' : '40px',
+                    position: 'sticky',
+                    right: getSummaryColumnRightOffset(idx, isMobile),
+                    backgroundColor: theme.palette.background.paper,
+                    zIndex: 2,
+                  }}
+                >
+                  {col.label}
+                </TableCell>
+              ))}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -284,27 +277,22 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                   )}
                 </TableCell>
               ))}
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-r-away"
-              >
-                {summaryData.away.runs}
-              </TableCell>
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-h-away"
-              >
-                {summaryData.away.hits}
-              </TableCell>
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-e-away"
-              >
-                {summaryData.away.errors}
-              </TableCell>
+              {SUMMARY_COLUMNS.map((col, idx) => (
+                <TableCell
+                  key={col.key}
+                  align="right"
+                  sx={{
+                    fontWeight: 'bold',
+                    position: 'sticky',
+                    right: getSummaryColumnRightOffset(idx, isMobile),
+                    backgroundColor: theme.palette.background.paper,
+                    zIndex: 1,
+                  }}
+                  data-testid={`scoreboard-${col.label.toLowerCase()}-away`}
+                >
+                  {summaryData.away[col.key]}
+                </TableCell>
+              ))}
             </TableRow>
 
             {/* 後攻チーム */}
@@ -352,27 +340,22 @@ const ScoreBoard: React.FC<ScoreBoardProps> = ({
                   )}
                 </TableCell>
               ))}
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-r-home"
-              >
-                {summaryData.home.runs}
-              </TableCell>
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-h-home"
-              >
-                {summaryData.home.hits}
-              </TableCell>
-              <TableCell
-                align="right"
-                sx={{ fontWeight: 'bold' }}
-                data-testid="scoreboard-e-home"
-              >
-                {summaryData.home.errors}
-              </TableCell>
+              {SUMMARY_COLUMNS.map((col, idx) => (
+                <TableCell
+                  key={col.key}
+                  align="right"
+                  sx={{
+                    fontWeight: 'bold',
+                    position: 'sticky',
+                    right: getSummaryColumnRightOffset(idx, isMobile),
+                    backgroundColor: theme.palette.background.paper,
+                    zIndex: 1,
+                  }}
+                  data-testid={`scoreboard-${col.label.toLowerCase()}-home`}
+                >
+                  {summaryData.home[col.key]}
+                </TableCell>
+              ))}
             </TableRow>
           </TableBody>
         </Table>

--- a/src/components/__tests__/ScoreBoard.a11y.test.tsx
+++ b/src/components/__tests__/ScoreBoard.a11y.test.tsx
@@ -86,29 +86,36 @@ describe('ScoreBoard accessibility', () => {
     expect(currentInningCells.length).toBe(3);
   });
 
-  test('total score column has descriptive label', () => {
+  test('total score, hit, and error columns have descriptive labels', () => {
     renderScoreBoard();
 
-    // 合計得点列にaria-labelがあること
     const totalHeader = screen.getByRole('columnheader', { name: /合計得点/i });
     expect(totalHeader).toBeInTheDocument();
     expect(totalHeader).toHaveAttribute('title', '合計得点');
+
+    const hitsHeader = screen.getByRole('columnheader', { name: /安打数/i });
+    expect(hitsHeader).toBeInTheDocument();
+    expect(hitsHeader).toHaveAttribute('title', '安打数');
+
+    const errorsHeader = screen.getByRole('columnheader', { name: /失策数/i });
+    expect(errorsHeader).toBeInTheDocument();
+    expect(errorsHeader).toHaveAttribute('title', '失策数');
   });
 
-  test('renders scoreboard heading and team summaries with R/H/E values', () => {
+  test('renders scoreboard heading and R/H/E values in table rows', () => {
     renderScoreBoard();
 
     expect(screen.getByText('スコアボード')).toBeInTheDocument();
-    const awaySummary = screen.getByTestId('scoreboard-summary-away');
-    const homeSummary = screen.getByTestId('scoreboard-summary-home');
+    expect(screen.getByTestId('scoreboard-r-away')).toHaveTextContent('0');
+    expect(screen.getByTestId('scoreboard-h-away')).toHaveTextContent('0');
+    expect(screen.getByTestId('scoreboard-e-away')).toHaveTextContent('0');
 
-    expect(awaySummary).toHaveTextContent(/チームB/);
-    expect(awaySummary).toHaveTextContent(/R 0 \/ H 0 \/ E 0/);
-    expect(homeSummary).toHaveTextContent(/チームA/);
-    expect(homeSummary).toHaveTextContent(/R 0 \/ H 0 \/ E 0/);
+    expect(screen.getByTestId('scoreboard-r-home')).toHaveTextContent('0');
+    expect(screen.getByTestId('scoreboard-h-home')).toHaveTextContent('0');
+    expect(screen.getByTestId('scoreboard-e-home')).toHaveTextContent('0');
   });
 
-  test('summary values reflect hits, errors, and run events', () => {
+  test('R/H/E values reflect hits, errors, and run events', () => {
     const scoringHomeTeam: Team = {
       ...mockTeamA,
       atBats: [
@@ -150,9 +157,9 @@ describe('ScoreBoard accessibility', () => {
       currentInning: 2,
     });
 
-    const homeSummary = screen.getByTestId('scoreboard-summary-home');
-
-    expect(homeSummary).toHaveTextContent(/R 3 \/ H 1 \/ E 1/);
+    expect(screen.getByTestId('scoreboard-r-home')).toHaveTextContent('3');
+    expect(screen.getByTestId('scoreboard-h-home')).toHaveTextContent('1');
+    expect(screen.getByTestId('scoreboard-e-home')).toHaveTextContent('1');
   });
 
   test('TypographyコンポーネントにfontWeightがsx経由で正しく適用されReactのDOM警告が出ない', () => {


### PR DESCRIPTION
## 概要
Issue #236 に対応し、スコアボードのテーブル右端に `R`（得点）・`H`（安打）・`E`（失策）の3列を追加して野球の標準的なスコアボード表示に統一し、表の上部にあった別枠のサマリーボックスを統合・削除しました。

## 変更内容
- **ScoreBoard.tsx**:
  - `SUMMARY_COLUMNS`（R, H, E）を定義し、ヘッダーおよび先攻・後攻チームの行末尾に R/H/E セルをレンダリング
  - 横スクロール時にも常に得点・安打・失策が確認できるよう、`position: sticky` と右オフセット（`right: ...`）を設定
  - 表外にあった別枠サマリーボックス（`data-testid="scoreboard-summary-*"`）および不要となった `teamSummaries`, `Box`, `Stack` を削除
- **ScoreBoard.a11y.test.tsx**:
  - R, H, E 列ヘッダーのアクセシビリティラベル（合計得点・安打数・失策数）のテスト
  - テーブル行内の R/H/E セル値表示および打撃・失策・得点イベント反映のテスト

## 実行したテスト
- `npm run ci:local` (全 35 スイート 221 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (全指摘事項を反映済み)

Closes #236
