### PR TITLE
chore: dependabot設定・axeヘルパー分離・prettier/gitignore整理

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,17 +23,10 @@ updates:
       mui:
         patterns:
           - '@mui/*'
+          - '@emotion/*'
     ignore:
-      # eslint-plugin-jest v28+ は @typescript-eslint v6+ を要求
-      # 現在は v5.62.0 を使用しているため互換性がない
-      - dependency-name: 'eslint-plugin-jest'
-        update-types: ['version-update:semver-major']
-      # TypeScript ESLint v8+ は破壊的変更が多く、
-      # react-scripts のアップデートが必要
-      - dependency-name: '@typescript-eslint/*'
-        update-types: ['version-update:semver-major']
-      # TypeScript v5+ は react-scripts 5.0.1 と互換性がない
-      # react-scripts は "^3.2.1 || ^4" のみサポート
+      # react-scripts は peer として TypeScript ^4 までしか宣言していないため
+      # メジャーアップデートは react-scripts 移行後に検討（現行は ^5.9.3 を使用中）
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
       # React v19+ は破壊的変更が多く、慎重な検証が必要

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,43 +19,43 @@ updates:
     labels:
       - 'dependencies'
       - 'javascript'
+    groups:
+      mui:
+        patterns:
+          - '@mui/*'
     ignore:
-      # eslint-plugin-jest v29+ は @typescript-eslint v8+ が必要で
-      # 現在の react-scripts 5.0.1 と互換性がない
-      - dependency-name: 'eslint-plugin-jest'
-        versions: ['>=29.0.0']
-      # TypeScript ESLint v8+ は破壊的変更が多く、
-      # react-scripts のアップデートが必要
-      - dependency-name: '@typescript-eslint/*'
-        versions: ['>=8.0.0']
-      # TypeScript v5+ は react-scripts 5.0.1 と互換性がない
-      # react-scripts は "^3.2.1 || ^4" のみサポート
-      - dependency-name: 'typescript'
-        versions: ['>=5.0.0']
-      # React v19+ は破壊的変更が多く、慎重な検証が必要
-      # 全体的なエコシステムアップデートが必要
-      - dependency-name: 'react'
-        versions: ['>=19.0.0']
-      - dependency-name: 'react-dom'
-        versions: ['>=19.0.0']
-      - dependency-name: '@types/react'
-        versions: ['>=19.0.0']
-      - dependency-name: '@types/react-dom'
-        versions: ['>=19.0.0']
-      # MUI v7+ は破壊的変更があり、段階的アップデートが必要
-      # @mui/icons-material とバージョン同期が必要
-      - dependency-name: '@mui/material'
-        versions: ['>=7.0.0']
-      - dependency-name: '@mui/icons-material'
-        versions: ['>=7.0.0']
       # eslint-plugin-jest v28+ は @typescript-eslint v6+ を要求
       # 現在は v5.62.0 を使用しているため互換性がない
       - dependency-name: 'eslint-plugin-jest'
-        versions: ['>=28.0.0']
+        update-types: ['version-update:semver-major']
+      # TypeScript ESLint v8+ は破壊的変更が多く、
+      # react-scripts のアップデートが必要
+      - dependency-name: '@typescript-eslint/*'
+        update-types: ['version-update:semver-major']
+      # TypeScript v5+ は react-scripts 5.0.1 と互換性がない
+      # react-scripts は "^3.2.1 || ^4" のみサポート
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      # React v19+ は破壊的変更が多く、慎重な検証が必要
+      # 全体的なエコシステムアップデートが必要
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+      # MUI v7+ は破壊的変更があり、段階的アップデートが必要
+      # @mui/icons-material とバージョン同期が必要
+      - dependency-name: '@mui/material'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@mui/icons-material'
+        update-types: ['version-update:semver-major']
       # web-vitals v5+ は破壊的変更が多い
       # getFID()関数削除、ReportHandler型変更など
       - dependency-name: 'web-vitals'
-        versions: ['>=5.0.0']
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions ワークフローの更新
   - package-ecosystem: 'github-actions'

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ node_modules/
 # misc
 .DS_Store
 ._*
+.serena/
 .env*
 !.env.example
+
 
 npm-debug.log*
 yarn-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,10 @@
 # Blog articles and documentation that don't need formatting
 qiita.md
 
-# Build output
+# Build and test output
 build/
 dist/
+coverage/
 
 # Dependencies
 node_modules/
@@ -15,4 +16,4 @@ node_modules/
 ._*
 
 # Git files
-.git/ 
+.git/

--- a/src/components/__tests__/AtBatForm.a11y.test.tsx
+++ b/src/components/__tests__/AtBatForm.a11y.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '../../setupTests';
+import { axe } from '../../test/axe';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import AtBatForm from '../AtBatForm';
 import { Player } from '../../types';

--- a/src/components/__tests__/HelpDialog.a11y.test.tsx
+++ b/src/components/__tests__/HelpDialog.a11y.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '../../setupTests';
+import { axe } from '../../test/axe';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import HelpDialog from '../HelpDialog';
 

--- a/src/components/__tests__/ScoreBoard.a11y.test.tsx
+++ b/src/components/__tests__/ScoreBoard.a11y.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from '../../setupTests';
+import { axe } from '../../test/axe';
+
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ScoreBoard from '../ScoreBoard';
 import { RunEvent, Team } from '../../types';

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,7 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
-import { configureAxe, toHaveNoViolations } from 'jest-axe';
+import { toHaveNoViolations } from 'jest-axe';
 
 // jest-axe のマッチャを登録
 expect.extend(toHaveNoViolations);
@@ -14,6 +14,3 @@ expect.extend(toHaveNoViolations);
 // 間に合わずフレーキーに失敗することがあるため、findBy* / waitFor の
 // 既定タイムアウトを緩和する
 configure({ asyncUtilTimeout: 8000 });
-
-// axeの設定（必要に応じてルール緩和をここで定義可能）
-export const axe = configureAxe({});

--- a/src/test/__tests__/axe.test.ts
+++ b/src/test/__tests__/axe.test.ts
@@ -1,0 +1,10 @@
+import { axe } from '../axe';
+
+describe('axe helper', () => {
+  test('DOM要素に対してアクセシビリティ検証を実行できる', async () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<main role="main"><h1>Title</h1></main>';
+    const results = await axe(el);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/test/axe.ts
+++ b/src/test/axe.ts
@@ -1,0 +1,4 @@
+import { configureAxe } from 'jest-axe';
+
+// 専用の axe ヘルパインスタンス
+export const axe = configureAxe({});


### PR DESCRIPTION
## 概要
Issue #210 に対応し、Dependabot の重複・無効ルールの整理、`axe` ヘルパーの独立モジュール（`src/test/axe.ts`）への分離、および `.prettierignore` / `.gitignore` の整理を実施しました。

## 変更内容
- **.github/dependabot.yml**:
  - `update-types: ['version-update:semver-major']` を採用し、互換性を保つ minor/patch 更新を許容しつつメジャー更新のみを適切にブロック
  - 存在しない直接依存（`eslint-plugin-jest`, `@typescript-eslint/*`）の無効な ignore 設定を削除
  - `@mui/*` および `@emotion/*` を同一グループ（`mui`）に統合してバージョン同期を容易化
- **src/test/axe.ts / setupTests.ts**:
  - `axe` インスタンスを `setupTests.ts` のグローバル副作用から切り離し、専用モジュール `src/test/axe.ts` に分離
  - 各 a11y テストファイル（`ScoreBoard`, `AtBatForm`, `HelpDialog`）のインポート先を更新
  - `src/test/__tests__/axe.test.ts` を追加
- **.prettierignore / .gitignore**:
  - `.prettierignore` の末尾スペースを除去し、`coverage/` を追加
  - `.gitignore` に `.serena/` を追加

## 実行したテスト
- `npm run ci:local` (全 36 スイート 222 テスト合格, prettier / eslint / tsc / build チェック通過)
- `ocr review` (全指摘事項を反映済み)

Closes #210
